### PR TITLE
Make sure waveform gets updated when player seeking is finished

### DIFF
--- a/components/video-player.tsx
+++ b/components/video-player.tsx
@@ -133,6 +133,12 @@ export default function VideoPlayer({
             onProgress(state.playedSeconds);
           }
         }}
+        onSeeked={() => {   // sometimes player.seeking is still true when onProgress is called, so this makes sure we update the waveform visualizer when seeking is done
+          if (playerRef.current) {
+            const currentTime = playerRef.current.getCurrentTime();
+            onProgress(currentTime);
+          }
+        }}
         onPlay={() => onPlayPause(true)}
         onPause={() => onPlayPause(false)}
         onDuration={onDuration}


### PR DESCRIPTION
Addresses #18. 

Call `onProgress` from `onSeeked` callback because sometimes 'seeking' is still 'true' for some reason in React Player's `onProgress` callback. 