### PR TITLE
fix: add space between texts when merging items

### DIFF
--- a/lib/subtitle-operations.ts
+++ b/lib/subtitle-operations.ts
@@ -253,7 +253,7 @@ export const mergeSubtitles = (
     id: sub1.id, // Will be reordered later
     startTime: sub1.startTime,
     endTime: sub2.endTime,
-    text: `${sub1.text}${sub2.text}`,
+    text: `${sub1.text} ${sub2.text}`,
   };
 
   const updatedSubtitles = subtitles


### PR DESCRIPTION
I was using this together with OpenAI's Whisper to fix multiple items that were too short. However, merging items doesn't add a space between the two texts. This PR fixes that.