### PR TITLE
[codex] Add subtitle QA review tool

### DIFF
--- a/components/app-header/app-header.tsx
+++ b/components/app-header/app-header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import FindReplace from "@/components/find-replace";
+import SubtitleQuality from "@/components/subtitle-quality";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -190,6 +191,8 @@ export function AppHeader({
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>
+
+        <SubtitleQuality />
 
         <FindReplace />
 

--- a/components/subtitle-quality/index.tsx
+++ b/components/subtitle-quality/index.tsx
@@ -1,0 +1,661 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  useSubtitleActionsContext,
+  useSubtitleState,
+  useSubtitles,
+} from "@/context/subtitle-context";
+import {
+  analyzeSubtitleQuality,
+  applySubtitleQualityFixes,
+  DEFAULT_SUBTITLE_QUALITY_OPTIONS,
+  SUBTITLE_QUALITY_RULES,
+  normalizeSubtitleQualityOptions,
+  type SubtitleIssue,
+  type SubtitleIssueSeverity,
+  type SubtitleQualityOptions,
+  type SubtitleQualityRuleId,
+} from "@/lib/subtitle-quality";
+import {
+  getReadableTextColor,
+  getTrackColor,
+  getTrackHandleColor,
+} from "@/lib/track-colors";
+import { cn } from "@/lib/utils";
+import type { Subtitle } from "@/types/subtitle";
+import type { CheckedState } from "@radix-ui/react-checkbox";
+import {
+  IconAlertTriangle,
+  IconChecks,
+  IconFilter,
+  IconShieldCheck,
+  IconTool,
+} from "@tabler/icons-react";
+import { useTranslations } from "next-intl";
+import { useEffect, useMemo, useState } from "react";
+
+const SEVERITIES: SubtitleIssueSeverity[] = ["error", "warning", "info"];
+
+const severityClasses: Record<SubtitleIssueSeverity, string> = {
+  error:
+    "border-red-600 bg-red-50 text-red-700 dark:border-red-400 dark:bg-red-950/40 dark:text-red-200",
+  warning:
+    "border-amber-500 bg-amber-50 text-amber-800 dark:border-amber-400 dark:bg-amber-950/40 dark:text-amber-100",
+  info: "border-sky-500 bg-sky-50 text-sky-800 dark:border-sky-400 dark:bg-sky-950/40 dark:text-sky-100",
+};
+
+const coerceCheckedState = (checked: CheckedState) =>
+  checked === "indeterminate" ? true : Boolean(checked);
+
+const formatTiming = (subtitle: Subtitle) =>
+  `${subtitle.startTime} -> ${subtitle.endTime}`;
+
+const getIssueFixLabel = (
+  issue: SubtitleIssue,
+  t: ReturnType<typeof useTranslations>,
+) => {
+  if (!issue.fix) {
+    return t("subtitleQuality.manualReview");
+  }
+  if (issue.fix.kind === "delete") {
+    return t("subtitleQuality.deleteCue");
+  }
+  if (issue.fix.kind === "timing") {
+    return t("subtitleQuality.timingFix");
+  }
+  return t("subtitleQuality.textFix");
+};
+
+const renderPreview = (
+  issue: SubtitleIssue,
+  subtitle: Subtitle | undefined,
+  t: ReturnType<typeof useTranslations>,
+) => {
+  if (!subtitle) {
+    return null;
+  }
+  if (!issue.fix) {
+    return (
+      <span className="text-muted-foreground">
+        {t("subtitleQuality.manualReview")}
+      </span>
+    );
+  }
+  if (issue.fix.kind === "delete") {
+    return (
+      <span className="font-medium text-red-700 dark:text-red-300">
+        {t("subtitleQuality.deleteCue")}
+      </span>
+    );
+  }
+  if (issue.fix.kind === "timing") {
+    return (
+      <div className="font-mono text-xs">
+        {issue.fix.startTime ?? subtitle.startTime}
+        {" -> "}
+        {issue.fix.endTime ?? subtitle.endTime}
+      </div>
+    );
+  }
+  return (
+    <span className="whitespace-pre-wrap">{issue.fix.replacementText}</span>
+  );
+};
+
+type ThresholdInputProps = {
+  id: string;
+  label: string;
+  value: number;
+  min: number;
+  step: number;
+  onChange: (value: number) => void;
+};
+
+function ThresholdInput({
+  id,
+  label,
+  value,
+  min,
+  step,
+  onChange,
+}: ThresholdInputProps) {
+  return (
+    <div className="grid gap-1">
+      <Label htmlFor={id} className="text-xs font-medium text-muted-foreground">
+        {label}
+      </Label>
+      <Input
+        id={id}
+        type="number"
+        min={min}
+        step={step}
+        value={value}
+        onChange={(event) => onChange(Number.parseFloat(event.target.value))}
+        className="h-8 rounded-xs px-2 text-sm"
+      />
+    </div>
+  );
+}
+
+export default function SubtitleQuality() {
+  const t = useTranslations();
+  const subtitles = useSubtitles();
+  const { replaceAllSubtitlesAction } = useSubtitleActionsContext();
+  const { activeTrack, tracks } = useSubtitleState();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [qualityOptions, setQualityOptions] = useState<SubtitleQualityOptions>(
+    DEFAULT_SUBTITLE_QUALITY_OPTIONS,
+  );
+  const [selectedIssueIds, setSelectedIssueIds] = useState<Set<string>>(
+    new Set(),
+  );
+  const [enabledSeverities, setEnabledSeverities] = useState<
+    Set<SubtitleIssueSeverity>
+  >(new Set(SEVERITIES));
+  const [enabledRuleIds, setEnabledRuleIds] = useState<
+    Set<SubtitleQualityRuleId>
+  >(new Set(SUBTITLE_QUALITY_RULES.map((rule) => rule.ruleId)));
+
+  const issues = useMemo(
+    () => analyzeSubtitleQuality(subtitles, qualityOptions),
+    [subtitles, qualityOptions],
+  );
+
+  const filteredIssues = useMemo(
+    () =>
+      issues.filter(
+        (issue) =>
+          enabledSeverities.has(issue.severity) &&
+          enabledRuleIds.has(issue.ruleId),
+      ),
+    [issues, enabledSeverities, enabledRuleIds],
+  );
+
+  const subtitlesByUuid = useMemo(
+    () => new Map(subtitles.map((subtitle) => [subtitle.uuid, subtitle])),
+    [subtitles],
+  );
+
+  const fixableFilteredIssues = filteredIssues.filter((issue) => issue.fix);
+  const fixableIssueIds = new Set(
+    fixableFilteredIssues.map((issue) => issue.id),
+  );
+  const selectedVisibleFixCount = fixableFilteredIssues.filter((issue) =>
+    selectedIssueIds.has(issue.id),
+  ).length;
+  const allVisibleFixesSelected =
+    fixableFilteredIssues.length > 0 &&
+    selectedVisibleFixCount === fixableFilteredIssues.length;
+  const headerCheckboxState: CheckedState = allVisibleFixesSelected
+    ? true
+    : selectedVisibleFixCount > 0
+      ? "indeterminate"
+      : false;
+
+  const activeTrackIndex = activeTrack
+    ? tracks.findIndex((track) => track.id === activeTrack.id)
+    : -1;
+  const normalizedTrackIndex = activeTrackIndex >= 0 ? activeTrackIndex : 0;
+  const trackHandleColor = getTrackHandleColor(normalizedTrackIndex);
+  const trackBackgroundColor = getTrackColor(normalizedTrackIndex, 0.12);
+  const trackTextColor = getReadableTextColor(trackHandleColor);
+  const isDisabled = !activeTrack || subtitles.length === 0;
+  const trackName =
+    activeTrack?.name ??
+    tracks[0]?.name ??
+    t("subtitle.newTrackName", { number: 1 });
+
+  useEffect(() => {
+    if (!isDialogOpen) {
+      return;
+    }
+    const issueIds = new Set(issues.map((issue) => issue.id));
+    setSelectedIssueIds((previous) => {
+      const next = new Set([...previous].filter((id) => issueIds.has(id)));
+      return next;
+    });
+  }, [isDialogOpen, issues]);
+
+  const updateQualityOption = (
+    key: keyof SubtitleQualityOptions,
+    value: number,
+  ) => {
+    setQualityOptions((previous) =>
+      normalizeSubtitleQualityOptions({
+        ...previous,
+        [key]: Number.isFinite(value) ? value : previous[key],
+      }),
+    );
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    setIsDialogOpen(open);
+    if (open) {
+      const nextIssues = analyzeSubtitleQuality(subtitles, qualityOptions);
+      setSelectedIssueIds(
+        new Set(
+          nextIssues.filter((issue) => issue.fix).map((issue) => issue.id),
+        ),
+      );
+    }
+  };
+
+  const toggleSeverity = (severity: SubtitleIssueSeverity) => {
+    setEnabledSeverities((previous) => {
+      const next = new Set(previous);
+      if (next.has(severity)) {
+        next.delete(severity);
+      } else {
+        next.add(severity);
+      }
+      return next;
+    });
+  };
+
+  const toggleRule = (ruleId: SubtitleQualityRuleId, enabled: boolean) => {
+    setEnabledRuleIds((previous) => {
+      const next = new Set(previous);
+      if (enabled) {
+        next.add(ruleId);
+      } else {
+        next.delete(ruleId);
+      }
+      return next;
+    });
+  };
+
+  const handleToggleAllVisible = (checked: CheckedState) => {
+    const shouldSelect = coerceCheckedState(checked);
+    setSelectedIssueIds((previous) => {
+      const next = new Set(previous);
+      for (const id of fixableIssueIds) {
+        if (shouldSelect) {
+          next.add(id);
+        } else {
+          next.delete(id);
+        }
+      }
+      return next;
+    });
+  };
+
+  const handleToggleIssue = (issueId: string, checked: CheckedState) => {
+    setSelectedIssueIds((previous) => {
+      const next = new Set(previous);
+      if (coerceCheckedState(checked)) {
+        next.add(issueId);
+      } else {
+        next.delete(issueId);
+      }
+      return next;
+    });
+  };
+
+  const handleApply = () => {
+    const selectedIssues = issues.filter(
+      (issue) => selectedIssueIds.has(issue.id) && issue.fix,
+    );
+    if (selectedIssues.length === 0) {
+      return;
+    }
+    const result = applySubtitleQualityFixes(
+      subtitles,
+      selectedIssues,
+      qualityOptions,
+    );
+    if (result.appliedIssueIds.length === 0) {
+      return;
+    }
+    replaceAllSubtitlesAction(result.subtitles);
+    setSelectedIssueIds(new Set());
+  };
+
+  return (
+    <Dialog open={isDialogOpen} onOpenChange={handleOpenChange}>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DialogTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                className="rounded-xs cursor-pointer border-black dark:border-white"
+                disabled={isDisabled}
+              >
+                <IconShieldCheck />
+                <span>{t("subtitleQuality.title")}</span>
+              </Button>
+            </DialogTrigger>
+          </TooltipTrigger>
+          <TooltipContent>{t("subtitleQuality.tooltip")}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <DialogContent className="sm:max-w-6xl">
+        <DialogHeader>
+          <DialogTitle>
+            {t("subtitleQuality.dialogTitle", { track: trackName })}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="grid gap-4">
+          <div
+            className="grid gap-3 border-l-4 px-4 py-3"
+            style={{
+              borderColor: trackHandleColor,
+              backgroundColor: trackBackgroundColor,
+            }}
+          >
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="flex items-center gap-2 text-sm">
+                <IconChecks
+                  className="size-4"
+                  style={{ color: trackHandleColor }}
+                />
+                <span>
+                  {t("subtitleQuality.summary", {
+                    issues: issues.length,
+                    selected: selectedIssueIds.size,
+                    fixable: issues.filter((issue) => issue.fix).length,
+                  })}
+                </span>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                {SEVERITIES.map((severity) => (
+                  <Button
+                    key={severity}
+                    type="button"
+                    size="sm"
+                    variant={
+                      enabledSeverities.has(severity) ? "default" : "outline"
+                    }
+                    aria-pressed={enabledSeverities.has(severity)}
+                    className={cn(
+                      "h-8 rounded-xs px-2 capitalize",
+                      enabledSeverities.has(severity) && "shadow-none",
+                    )}
+                    onClick={() => toggleSeverity(severity)}
+                  >
+                    {t(`subtitleQuality.severity.${severity}`)}
+                  </Button>
+                ))}
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      className="h-8 rounded-xs"
+                    >
+                      <IconFilter />
+                      {t("subtitleQuality.rules")}
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="w-56">
+                    <DropdownMenuLabel>
+                      {t("subtitleQuality.rules")}
+                    </DropdownMenuLabel>
+                    <DropdownMenuSeparator />
+                    {SUBTITLE_QUALITY_RULES.map((rule) => (
+                      <DropdownMenuCheckboxItem
+                        key={rule.ruleId}
+                        checked={enabledRuleIds.has(rule.ruleId)}
+                        onSelect={(event) => event.preventDefault()}
+                        onCheckedChange={(checked) =>
+                          toggleRule(rule.ruleId, checked)
+                        }
+                      >
+                        {rule.label}
+                      </DropdownMenuCheckboxItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            </div>
+
+            <div className="grid gap-2 sm:grid-cols-4">
+              <ThresholdInput
+                id="quality-min-duration"
+                label={t("subtitleQuality.minDuration")}
+                value={qualityOptions.minDurationSeconds}
+                min={0.1}
+                step={0.1}
+                onChange={(value) =>
+                  updateQualityOption("minDurationSeconds", value)
+                }
+              />
+              <ThresholdInput
+                id="quality-max-duration"
+                label={t("subtitleQuality.maxDuration")}
+                value={qualityOptions.maxDurationSeconds}
+                min={0.1}
+                step={0.1}
+                onChange={(value) =>
+                  updateQualityOption("maxDurationSeconds", value)
+                }
+              />
+              <ThresholdInput
+                id="quality-max-chars"
+                label={t("subtitleQuality.maxChars")}
+                value={qualityOptions.maxCharactersPerLine}
+                min={1}
+                step={1}
+                onChange={(value) =>
+                  updateQualityOption("maxCharactersPerLine", value)
+                }
+              />
+              <ThresholdInput
+                id="quality-max-lines"
+                label={t("subtitleQuality.maxLines")}
+                value={qualityOptions.maxLinesPerCue}
+                min={1}
+                step={1}
+                onChange={(value) =>
+                  updateQualityOption("maxLinesPerCue", value)
+                }
+              />
+            </div>
+          </div>
+
+          <Table
+            containerClassName="max-h-[34rem] overflow-y-auto border"
+            className="w-full border-collapse text-sm"
+          >
+            <TableHeader>
+              <TableRow>
+                <TableHead
+                  className="sticky top-0 z-20 w-10 border-b bg-background text-center"
+                  style={{
+                    backgroundColor: trackHandleColor,
+                    color: trackTextColor,
+                  }}
+                >
+                  <Checkbox
+                    checked={headerCheckboxState}
+                    disabled={fixableFilteredIssues.length === 0}
+                    onCheckedChange={handleToggleAllVisible}
+                    aria-label={t("subtitleQuality.selectVisible")}
+                  />
+                </TableHead>
+                <TableHead
+                  className="sticky top-0 z-20 w-16 border-b bg-background"
+                  style={{
+                    backgroundColor: trackHandleColor,
+                    color: trackTextColor,
+                  }}
+                >
+                  {t("subtitleQuality.cue")}
+                </TableHead>
+                <TableHead
+                  className="sticky top-0 z-20 w-36 border-b bg-background"
+                  style={{
+                    backgroundColor: trackHandleColor,
+                    color: trackTextColor,
+                  }}
+                >
+                  {t("subtitleQuality.issue")}
+                </TableHead>
+                <TableHead
+                  className="sticky top-0 z-20 border-b bg-background"
+                  style={{
+                    backgroundColor: trackHandleColor,
+                    color: trackTextColor,
+                  }}
+                >
+                  {t("subtitleQuality.original")}
+                </TableHead>
+                <TableHead
+                  className="sticky top-0 z-20 border-b bg-background"
+                  style={{
+                    backgroundColor: trackHandleColor,
+                    color: trackTextColor,
+                  }}
+                >
+                  {t("subtitleQuality.preview")}
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filteredIssues.length > 0 ? (
+                filteredIssues.map((issue) => {
+                  const subtitle = subtitlesByUuid.get(issue.subtitleUuid);
+                  const isFixable = Boolean(issue.fix);
+                  return (
+                    <TableRow
+                      key={issue.id}
+                      className="border-b border-dashed hover:bg-muted/50"
+                    >
+                      <TableCell className="text-center align-top">
+                        <Checkbox
+                          checked={selectedIssueIds.has(issue.id)}
+                          disabled={!isFixable}
+                          onCheckedChange={(checked) =>
+                            handleToggleIssue(issue.id, checked)
+                          }
+                          aria-label={t("subtitleQuality.selectIssue", {
+                            id: issue.subtitleId,
+                          })}
+                        />
+                      </TableCell>
+                      <TableCell className="align-top font-mono text-xs">
+                        #{issue.subtitleId}
+                      </TableCell>
+                      <TableCell className="align-top">
+                        <div className="grid gap-1">
+                          <span
+                            className={cn(
+                              "w-fit rounded-xs border px-2 py-0.5 text-xs font-medium capitalize",
+                              severityClasses[issue.severity],
+                            )}
+                          >
+                            {t(`subtitleQuality.severity.${issue.severity}`)}
+                          </span>
+                          <span className="font-medium">{issue.ruleLabel}</span>
+                          <span className="text-xs text-muted-foreground">
+                            {issue.message}
+                          </span>
+                        </div>
+                      </TableCell>
+                      <TableCell className="align-top">
+                        <div className="grid gap-1">
+                          {subtitle && (
+                            <span className="font-mono text-xs text-muted-foreground">
+                              {formatTiming(subtitle)}
+                            </span>
+                          )}
+                          <span className="whitespace-pre-wrap break-words">
+                            {subtitle?.text}
+                          </span>
+                        </div>
+                      </TableCell>
+                      <TableCell className="align-top">
+                        <div className="grid gap-1">
+                          <span className="text-xs font-medium text-muted-foreground">
+                            {getIssueFixLabel(issue, t)}
+                          </span>
+                          {renderPreview(issue, subtitle, t)}
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={5} className="py-8 text-center">
+                    <div className="flex items-center justify-center gap-2 text-muted-foreground">
+                      <IconAlertTriangle className="size-4" />
+                      {issues.length === 0
+                        ? t("subtitleQuality.noIssues")
+                        : t("subtitleQuality.noFilteredIssues")}
+                    </div>
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            className="rounded-xs"
+            onClick={() =>
+              setSelectedIssueIds(
+                new Set(
+                  issues.filter((issue) => issue.fix).map((issue) => issue.id),
+                ),
+              )
+            }
+            disabled={issues.every((issue) => !issue.fix)}
+          >
+            <IconChecks />
+            {t("subtitleQuality.selectFixes")}
+          </Button>
+          <Button
+            type="button"
+            className="rounded-xs"
+            onClick={handleApply}
+            disabled={selectedIssueIds.size === 0}
+          >
+            <IconTool />
+            {t("subtitleQuality.apply")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/lib/subtitle-quality.ts
+++ b/lib/subtitle-quality.ts
@@ -1,0 +1,668 @@
+import { reorderSubtitleIds } from "@/lib/subtitle-operations";
+import { secondsToTime, timeToSeconds } from "@/lib/utils";
+import type { Subtitle } from "@/types/subtitle";
+
+export type SubtitleIssueSeverity = "error" | "warning" | "info";
+
+export type SubtitleQualityRuleId =
+  | "empty-cue"
+  | "trim-whitespace"
+  | "repeated-whitespace"
+  | "repeated-word"
+  | "invalid-duration"
+  | "overlap"
+  | "min-duration"
+  | "max-duration"
+  | "line-length"
+  | "line-count"
+  | "unbalanced-tags";
+
+export interface SubtitleQualityOptions {
+  minDurationSeconds: number;
+  maxDurationSeconds: number;
+  maxCharactersPerLine: number;
+  maxLinesPerCue: number;
+}
+
+export type SubtitleIssueFix =
+  | { kind: "delete" }
+  | { kind: "text"; replacementText: string }
+  | { kind: "timing"; startTime?: string; endTime?: string };
+
+export interface SubtitleIssue {
+  id: string;
+  ruleId: SubtitleQualityRuleId;
+  ruleLabel: string;
+  subtitleUuid: string;
+  subtitleId: number;
+  severity: SubtitleIssueSeverity;
+  message: string;
+  fix?: SubtitleIssueFix;
+}
+
+export interface SubtitleFixRule {
+  ruleId: SubtitleQualityRuleId;
+  label: string;
+  detect: (
+    subtitles: Subtitle[],
+    options: SubtitleQualityOptions,
+  ) => SubtitleIssue[];
+  apply?: (
+    subtitles: Subtitle[],
+    issue: SubtitleIssue,
+    options: SubtitleQualityOptions,
+  ) => Subtitle[];
+}
+
+export interface ApplySubtitleQualityFixesResult {
+  subtitles: Subtitle[];
+  appliedIssueIds: string[];
+}
+
+export const DEFAULT_SUBTITLE_QUALITY_OPTIONS: SubtitleQualityOptions = {
+  minDurationSeconds: 1,
+  maxDurationSeconds: 7,
+  maxCharactersPerLine: 42,
+  maxLinesPerCue: 2,
+};
+
+const clampNumber = (value: number, fallback: number, min: number) =>
+  Number.isFinite(value) && value >= min ? value : fallback;
+
+export function normalizeSubtitleQualityOptions(
+  options: Partial<SubtitleQualityOptions> = {},
+): SubtitleQualityOptions {
+  const minDurationSeconds = clampNumber(
+    options.minDurationSeconds ??
+      DEFAULT_SUBTITLE_QUALITY_OPTIONS.minDurationSeconds,
+    DEFAULT_SUBTITLE_QUALITY_OPTIONS.minDurationSeconds,
+    0.1,
+  );
+  const maxDurationSeconds = Math.max(
+    minDurationSeconds,
+    clampNumber(
+      options.maxDurationSeconds ??
+        DEFAULT_SUBTITLE_QUALITY_OPTIONS.maxDurationSeconds,
+      DEFAULT_SUBTITLE_QUALITY_OPTIONS.maxDurationSeconds,
+      0.1,
+    ),
+  );
+
+  return {
+    minDurationSeconds,
+    maxDurationSeconds,
+    maxCharactersPerLine: Math.round(
+      clampNumber(
+        options.maxCharactersPerLine ??
+          DEFAULT_SUBTITLE_QUALITY_OPTIONS.maxCharactersPerLine,
+        DEFAULT_SUBTITLE_QUALITY_OPTIONS.maxCharactersPerLine,
+        1,
+      ),
+    ),
+    maxLinesPerCue: Math.round(
+      clampNumber(
+        options.maxLinesPerCue ??
+          DEFAULT_SUBTITLE_QUALITY_OPTIONS.maxLinesPerCue,
+        DEFAULT_SUBTITLE_QUALITY_OPTIONS.maxLinesPerCue,
+        1,
+      ),
+    ),
+  };
+}
+
+const issueId = (ruleId: SubtitleQualityRuleId, subtitle: Subtitle) =>
+  `${ruleId}:${subtitle.uuid}`;
+
+const makeIssue = (
+  rule: Pick<SubtitleFixRule, "ruleId" | "label">,
+  subtitle: Subtitle,
+  severity: SubtitleIssueSeverity,
+  message: string,
+  fix?: SubtitleIssueFix,
+): SubtitleIssue => ({
+  id: issueId(rule.ruleId, subtitle),
+  ruleId: rule.ruleId,
+  ruleLabel: rule.label,
+  subtitleUuid: subtitle.uuid,
+  subtitleId: subtitle.id,
+  severity,
+  message,
+  fix,
+});
+
+const updateSubtitleByUuid = (
+  subtitles: Subtitle[],
+  uuid: string,
+  update: (subtitle: Subtitle, index: number) => Subtitle,
+): Subtitle[] => {
+  let changed = false;
+  const updated = subtitles.map((subtitle, index) => {
+    if (subtitle.uuid !== uuid) {
+      return subtitle;
+    }
+    const next = update(subtitle, index);
+    if (next !== subtitle) {
+      changed = true;
+    }
+    return next;
+  });
+  return changed ? updated : subtitles;
+};
+
+const deleteSubtitleByUuid = (subtitles: Subtitle[], uuid: string) => {
+  const next = subtitles.filter((subtitle) => subtitle.uuid !== uuid);
+  return next.length === subtitles.length
+    ? subtitles
+    : reorderSubtitleIds(next);
+};
+
+const applyTextFix = (subtitles: Subtitle[], issue: SubtitleIssue) => {
+  const fix = issue.fix;
+  if (!fix || fix.kind !== "text") {
+    return subtitles;
+  }
+  return updateSubtitleByUuid(subtitles, issue.subtitleUuid, (subtitle) => {
+    if (subtitle.text === fix.replacementText) {
+      return subtitle;
+    }
+    return { ...subtitle, text: fix.replacementText };
+  });
+};
+
+const applyTimingFix = (subtitles: Subtitle[], issue: SubtitleIssue) => {
+  const fix = issue.fix;
+  if (!fix || fix.kind !== "timing") {
+    return subtitles;
+  }
+  return updateSubtitleByUuid(subtitles, issue.subtitleUuid, (subtitle) => {
+    const startTime = fix.startTime ?? subtitle.startTime;
+    const endTime = fix.endTime ?? subtitle.endTime;
+    if (subtitle.startTime === startTime && subtitle.endTime === endTime) {
+      return subtitle;
+    }
+    return { ...subtitle, startTime, endTime };
+  });
+};
+
+const countCharacters = (text: string) => Array.from(text).length;
+
+const normalizeRepeatedWhitespace = (text: string) =>
+  text
+    .split(/\r?\n/)
+    .map((line) => line.replace(/[^\S\r\n]{2,}/gu, " "))
+    .join("\n");
+
+const REPEATED_WORD_REGEX = /\b([\p{L}\p{N}][\p{L}\p{N}'-]*)\b\s+\1\b/giu;
+
+const normalizeRepeatedWords = (text: string) => {
+  let next = text;
+  for (let pass = 0; pass < 8; pass += 1) {
+    const replaced = next.replace(REPEATED_WORD_REGEX, "$1");
+    if (replaced === next) {
+      return next;
+    }
+    next = replaced;
+  }
+  return next;
+};
+
+const wrapLineToLength = (line: string, maxCharacters: number) => {
+  const words = line.trim().split(/\s+/u).filter(Boolean);
+  if (words.length === 0) {
+    return line.trim();
+  }
+
+  const wrapped: string[] = [];
+  let current = "";
+
+  for (const word of words) {
+    if (current.length === 0) {
+      current = word;
+      continue;
+    }
+    if (countCharacters(`${current} ${word}`) <= maxCharacters) {
+      current = `${current} ${word}`;
+      continue;
+    }
+    wrapped.push(current);
+    current = word;
+  }
+
+  if (current.length > 0) {
+    wrapped.push(current);
+  }
+
+  return wrapped.join("\n");
+};
+
+const wrapTextToLineLength = (text: string, maxCharacters: number) =>
+  text
+    .split(/\r?\n/)
+    .map((line) =>
+      countCharacters(line) > maxCharacters
+        ? wrapLineToLength(line, maxCharacters)
+        : line,
+    )
+    .join("\n");
+
+const rebalanceTextToLineCount = (text: string, maxLines: number) => {
+  const words = text.replace(/\s+/gu, " ").trim().split(" ").filter(Boolean);
+  if (words.length === 0) {
+    return text.trim();
+  }
+
+  const totalCharacters = words.reduce(
+    (total, word) => total + countCharacters(word),
+    0,
+  );
+  const targetCharacters = Math.max(
+    1,
+    Math.ceil((totalCharacters + words.length - 1) / maxLines),
+  );
+  const lines: string[] = [];
+  let current = "";
+
+  for (const word of words) {
+    if (current.length === 0) {
+      current = word;
+      continue;
+    }
+    if (
+      lines.length < maxLines - 1 &&
+      countCharacters(`${current} ${word}`) > targetCharacters
+    ) {
+      lines.push(current);
+      current = word;
+      continue;
+    }
+    current = `${current} ${word}`;
+  }
+
+  if (current.length > 0) {
+    lines.push(current);
+  }
+
+  return lines
+    .slice(0, maxLines - 1)
+    .concat(lines.slice(maxLines - 1).join(" "))
+    .join("\n");
+};
+
+const hasUnbalancedBasicTags = (text: string) => {
+  const stack: string[] = [];
+  let hasMismatch = false;
+  const tagRegex = /<\/?([ibu])>/giu;
+  for (const match of text.matchAll(tagRegex)) {
+    const fullTag = match[0].toLowerCase();
+    const tagName = match[1].toLowerCase();
+    if (fullTag.startsWith("</")) {
+      if (stack[stack.length - 1] === tagName) {
+        stack.pop();
+      } else {
+        hasMismatch = true;
+      }
+    } else {
+      stack.push(tagName);
+    }
+  }
+  return hasMismatch || stack.length > 0;
+};
+
+const emptyCueRule: SubtitleFixRule = {
+  ruleId: "empty-cue",
+  label: "Empty cue",
+  detect: (subtitles) =>
+    subtitles
+      .filter((subtitle) => subtitle.text.trim().length === 0)
+      .map((subtitle) =>
+        makeIssue(
+          emptyCueRule,
+          subtitle,
+          "warning",
+          "Cue text is empty or only whitespace.",
+          { kind: "delete" },
+        ),
+      ),
+  apply: (subtitles, issue) =>
+    deleteSubtitleByUuid(subtitles, issue.subtitleUuid),
+};
+
+const trimWhitespaceRule: SubtitleFixRule = {
+  ruleId: "trim-whitespace",
+  label: "Trim whitespace",
+  detect: (subtitles) =>
+    subtitles.flatMap((subtitle) => {
+      const replacementText = subtitle.text.trim();
+      if (
+        replacementText === subtitle.text ||
+        subtitle.text.trim().length === 0
+      ) {
+        return [];
+      }
+      return [
+        makeIssue(
+          trimWhitespaceRule,
+          subtitle,
+          "info",
+          "Cue text has leading or trailing whitespace.",
+          { kind: "text", replacementText },
+        ),
+      ];
+    }),
+  apply: applyTextFix,
+};
+
+const repeatedWhitespaceRule: SubtitleFixRule = {
+  ruleId: "repeated-whitespace",
+  label: "Repeated whitespace",
+  detect: (subtitles) =>
+    subtitles.flatMap((subtitle) => {
+      const replacementText = normalizeRepeatedWhitespace(subtitle.text);
+      if (replacementText === subtitle.text) {
+        return [];
+      }
+      return [
+        makeIssue(
+          repeatedWhitespaceRule,
+          subtitle,
+          "info",
+          "Cue text has repeated spaces or tabs.",
+          { kind: "text", replacementText },
+        ),
+      ];
+    }),
+  apply: applyTextFix,
+};
+
+const repeatedWordRule: SubtitleFixRule = {
+  ruleId: "repeated-word",
+  label: "Repeated word",
+  detect: (subtitles) =>
+    subtitles.flatMap((subtitle) => {
+      const replacementText = normalizeRepeatedWords(subtitle.text);
+      if (replacementText === subtitle.text) {
+        return [];
+      }
+      return [
+        makeIssue(
+          repeatedWordRule,
+          subtitle,
+          "info",
+          "Cue text has consecutive repeated words.",
+          { kind: "text", replacementText },
+        ),
+      ];
+    }),
+  apply: applyTextFix,
+};
+
+const invalidDurationRule: SubtitleFixRule = {
+  ruleId: "invalid-duration",
+  label: "Invalid duration",
+  detect: (subtitles, options) =>
+    subtitles.flatMap((subtitle) => {
+      const startSeconds = timeToSeconds(subtitle.startTime);
+      const endSeconds = timeToSeconds(subtitle.endTime);
+      if (!Number.isFinite(startSeconds) || !Number.isFinite(endSeconds)) {
+        return [
+          makeIssue(
+            invalidDurationRule,
+            subtitle,
+            "error",
+            "Cue has an invalid timestamp.",
+          ),
+        ];
+      }
+      if (endSeconds > startSeconds) {
+        return [];
+      }
+      return [
+        makeIssue(
+          invalidDurationRule,
+          subtitle,
+          "error",
+          "Cue end time is earlier than or equal to the start time.",
+          {
+            kind: "timing",
+            endTime: secondsToTime(startSeconds + options.minDurationSeconds),
+          },
+        ),
+      ];
+    }),
+  apply: applyTimingFix,
+};
+
+const overlapRule: SubtitleFixRule = {
+  ruleId: "overlap",
+  label: "Overlap",
+  detect: (subtitles, options) =>
+    subtitles.flatMap((subtitle, index) => {
+      if (index === 0) {
+        return [];
+      }
+      const previous = subtitles[index - 1];
+      const previousEnd = timeToSeconds(previous.endTime);
+      const startSeconds = timeToSeconds(subtitle.startTime);
+      const endSeconds = timeToSeconds(subtitle.endTime);
+      if (
+        !Number.isFinite(previousEnd) ||
+        !Number.isFinite(startSeconds) ||
+        !Number.isFinite(endSeconds) ||
+        startSeconds >= previousEnd
+      ) {
+        return [];
+      }
+      return [
+        makeIssue(
+          overlapRule,
+          subtitle,
+          "error",
+          `Cue overlaps the previous cue by ${(previousEnd - startSeconds).toFixed(3)}s.`,
+          {
+            kind: "timing",
+            startTime: secondsToTime(previousEnd),
+            endTime: secondsToTime(
+              Math.max(endSeconds, previousEnd + options.minDurationSeconds),
+            ),
+          },
+        ),
+      ];
+    }),
+  apply: applyTimingFix,
+};
+
+const minDurationRule: SubtitleFixRule = {
+  ruleId: "min-duration",
+  label: "Minimum duration",
+  detect: (subtitles, options) =>
+    subtitles.flatMap((subtitle) => {
+      const startSeconds = timeToSeconds(subtitle.startTime);
+      const endSeconds = timeToSeconds(subtitle.endTime);
+      const duration = endSeconds - startSeconds;
+      if (
+        !Number.isFinite(duration) ||
+        duration <= 0 ||
+        duration >= options.minDurationSeconds
+      ) {
+        return [];
+      }
+      return [
+        makeIssue(
+          minDurationRule,
+          subtitle,
+          "warning",
+          `Cue duration is below ${options.minDurationSeconds.toFixed(1)}s.`,
+          {
+            kind: "timing",
+            endTime: secondsToTime(startSeconds + options.minDurationSeconds),
+          },
+        ),
+      ];
+    }),
+  apply: applyTimingFix,
+};
+
+const maxDurationRule: SubtitleFixRule = {
+  ruleId: "max-duration",
+  label: "Maximum duration",
+  detect: (subtitles, options) =>
+    subtitles.flatMap((subtitle) => {
+      const startSeconds = timeToSeconds(subtitle.startTime);
+      const endSeconds = timeToSeconds(subtitle.endTime);
+      const duration = endSeconds - startSeconds;
+      if (
+        !Number.isFinite(duration) ||
+        duration <= options.maxDurationSeconds
+      ) {
+        return [];
+      }
+      return [
+        makeIssue(
+          maxDurationRule,
+          subtitle,
+          "warning",
+          `Cue duration is above ${options.maxDurationSeconds.toFixed(1)}s.`,
+          {
+            kind: "timing",
+            endTime: secondsToTime(startSeconds + options.maxDurationSeconds),
+          },
+        ),
+      ];
+    }),
+  apply: applyTimingFix,
+};
+
+const lineLengthRule: SubtitleFixRule = {
+  ruleId: "line-length",
+  label: "Line length",
+  detect: (subtitles, options) =>
+    subtitles.flatMap((subtitle) => {
+      const lines = subtitle.text.split(/\r?\n/);
+      const hasLongLine = lines.some(
+        (line) => countCharacters(line) > options.maxCharactersPerLine,
+      );
+      if (!hasLongLine) {
+        return [];
+      }
+      const replacementText = wrapTextToLineLength(
+        subtitle.text,
+        options.maxCharactersPerLine,
+      );
+      return [
+        makeIssue(
+          lineLengthRule,
+          subtitle,
+          "warning",
+          `Cue has a line over ${options.maxCharactersPerLine} characters.`,
+          replacementText !== subtitle.text
+            ? { kind: "text", replacementText }
+            : undefined,
+        ),
+      ];
+    }),
+  apply: applyTextFix,
+};
+
+const lineCountRule: SubtitleFixRule = {
+  ruleId: "line-count",
+  label: "Line count",
+  detect: (subtitles, options) =>
+    subtitles.flatMap((subtitle) => {
+      const lines = subtitle.text.split(/\r?\n/);
+      if (lines.length <= options.maxLinesPerCue) {
+        return [];
+      }
+      const replacementText = rebalanceTextToLineCount(
+        subtitle.text,
+        options.maxLinesPerCue,
+      );
+      return [
+        makeIssue(
+          lineCountRule,
+          subtitle,
+          "warning",
+          `Cue has more than ${options.maxLinesPerCue} lines.`,
+          replacementText !== subtitle.text
+            ? { kind: "text", replacementText }
+            : undefined,
+        ),
+      ];
+    }),
+  apply: applyTextFix,
+};
+
+const unbalancedTagsRule: SubtitleFixRule = {
+  ruleId: "unbalanced-tags",
+  label: "Unbalanced tags",
+  detect: (subtitles) =>
+    subtitles
+      .filter((subtitle) => hasUnbalancedBasicTags(subtitle.text))
+      .map((subtitle) =>
+        makeIssue(
+          unbalancedTagsRule,
+          subtitle,
+          "warning",
+          "Cue has unbalanced <i>, <b>, or <u> tags.",
+        ),
+      ),
+};
+
+const RULES: SubtitleFixRule[] = [
+  emptyCueRule,
+  trimWhitespaceRule,
+  repeatedWhitespaceRule,
+  repeatedWordRule,
+  invalidDurationRule,
+  overlapRule,
+  minDurationRule,
+  maxDurationRule,
+  lineLengthRule,
+  lineCountRule,
+  unbalancedTagsRule,
+];
+
+export const SUBTITLE_QUALITY_RULES = RULES.map(({ ruleId, label }) => ({
+  ruleId,
+  label,
+}));
+
+export function analyzeSubtitleQuality(
+  subtitles: Subtitle[],
+  options: Partial<SubtitleQualityOptions> = {},
+): SubtitleIssue[] {
+  const normalizedOptions = normalizeSubtitleQualityOptions(options);
+  return RULES.flatMap((rule) => rule.detect(subtitles, normalizedOptions));
+}
+
+export function applySubtitleQualityFixes(
+  subtitles: Subtitle[],
+  issues: SubtitleIssue[],
+  options: Partial<SubtitleQualityOptions> = {},
+): ApplySubtitleQualityFixesResult {
+  const normalizedOptions = normalizeSubtitleQualityOptions(options);
+  const selectedIssueIds = new Set(issues.map((issue) => issue.id));
+  const appliedIssueIds: string[] = [];
+  let nextSubtitles = subtitles;
+
+  for (const rule of RULES) {
+    if (!rule.apply) {
+      continue;
+    }
+    const currentIssues = rule
+      .detect(nextSubtitles, normalizedOptions)
+      .filter((issue) => selectedIssueIds.has(issue.id) && issue.fix);
+
+    for (const issue of currentIssues) {
+      const updated = rule.apply(nextSubtitles, issue, normalizedOptions);
+      if (updated !== nextSubtitles) {
+        nextSubtitles = updated;
+        appliedIssueIds.push(issue.id);
+      }
+    }
+  }
+
+  return {
+    subtitles: appliedIssueIds.length > 0 ? nextSubtitles : subtitles,
+    appliedIssueIds,
+  };
+}

--- a/messages/de.json
+++ b/messages/de.json
@@ -65,6 +65,36 @@
     "noMatches": "Keine Übereinstimmungen gefunden",
     "replace": "Ersetzen"
   },
+  "subtitleQuality": {
+    "title": "QA",
+    "tooltip": "Häufige Untertitelprobleme prüfen",
+    "dialogTitle": "Untertitel-QA für aktuelle Spur: {track}",
+    "summary": "{issues} Probleme · {selected} ausgewählt · {fixable} automatisch korrigierbar",
+    "rules": "Regeln",
+    "minDuration": "Mindestdauer (s)",
+    "maxDuration": "Höchstdauer (s)",
+    "maxChars": "Max. Zeichen / Zeile",
+    "maxLines": "Max. Zeilen",
+    "cue": "Cue",
+    "issue": "Problem",
+    "original": "Original",
+    "preview": "Vorschau",
+    "manualReview": "Manuell prüfen",
+    "deleteCue": "Cue löschen",
+    "timingFix": "Timing-Korrektur",
+    "textFix": "Textkorrektur",
+    "selectVisible": "Sichtbare Korrekturen auswählen",
+    "selectIssue": "Problem für Cue {id} auswählen",
+    "selectFixes": "Korrekturen auswählen",
+    "apply": "Korrekturen anwenden",
+    "noIssues": "Keine Probleme gefunden",
+    "noFilteredIssues": "Keine Probleme passen zu den aktuellen Filtern",
+    "severity": {
+      "error": "Fehler",
+      "warning": "Warnung",
+      "info": "Info"
+    }
+  },
   "bulkOffset": {
     "title": "Untertitel für die Stapelverschiebung der Zeitstempel auswählen. Aktuelle Spur: {track}",
     "emptyState": "Lade Untertitel, um Sammelverschiebungen zu aktivieren.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -65,6 +65,36 @@
     "noMatches": "No matches found",
     "replace": "Replace"
   },
+  "subtitleQuality": {
+    "title": "QA",
+    "tooltip": "Review common subtitle issues",
+    "dialogTitle": "Subtitle QA for current track: {track}",
+    "summary": "{issues} issues · {selected} selected · {fixable} fixable",
+    "rules": "Rules",
+    "minDuration": "Min duration (s)",
+    "maxDuration": "Max duration (s)",
+    "maxChars": "Max chars / line",
+    "maxLines": "Max lines",
+    "cue": "Cue",
+    "issue": "Issue",
+    "original": "Original",
+    "preview": "Preview",
+    "manualReview": "Review manually",
+    "deleteCue": "Delete cue",
+    "timingFix": "Timing fix",
+    "textFix": "Text fix",
+    "selectVisible": "Select visible fixes",
+    "selectIssue": "Select issue for cue {id}",
+    "selectFixes": "Select fixes",
+    "apply": "Apply fixes",
+    "noIssues": "No issues found",
+    "noFilteredIssues": "No issues match the current filters",
+    "severity": {
+      "error": "error",
+      "warning": "warning",
+      "info": "info"
+    }
+  },
   "bulkOffset": {
     "title": "Select subtitles to bulk offset timestamps of current track: {track}",
     "emptyState": "Load subtitles to enable bulk offsets.",

--- a/messages/yue.json
+++ b/messages/yue.json
@@ -65,6 +65,36 @@
     "noMatches": "揾唔到匹配項",
     "replace": "替換"
   },
+  "subtitleQuality": {
+    "title": "QA",
+    "tooltip": "檢查常見字幕問題",
+    "dialogTitle": "當前字幕軌 QA：{track}",
+    "summary": "{issues} 個問題 · 已揀 {selected} · {fixable} 個可自動修正",
+    "rules": "規則",
+    "minDuration": "最短時長（秒）",
+    "maxDuration": "最長時長（秒）",
+    "maxChars": "每行最多字元",
+    "maxLines": "最多行數",
+    "cue": "字幕",
+    "issue": "問題",
+    "original": "當前",
+    "preview": "預覽",
+    "manualReview": "人手檢查",
+    "deleteCue": "刪除字幕",
+    "timingFix": "時間修正",
+    "textFix": "文字修正",
+    "selectVisible": "揀可見修正",
+    "selectIssue": "揀字幕 {id} 嘅問題",
+    "selectFixes": "揀修正",
+    "apply": "套用修正",
+    "noIssues": "冇搵到問題",
+    "noFilteredIssues": "目前篩選冇相符問題",
+    "severity": {
+      "error": "錯誤",
+      "warning": "警告",
+      "info": "資訊"
+    }
+  },
   "bulkOffset": {
     "title": "揀字幕批量位移當前字幕軌：{track}",
     "emptyState": "載入字幕先可以批量位移時間。",

--- a/tests/subtitle-quality.test.ts
+++ b/tests/subtitle-quality.test.ts
@@ -1,0 +1,200 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  analyzeSubtitleQuality,
+  applySubtitleQualityFixes,
+  type SubtitleQualityRuleId,
+} from "../lib/subtitle-quality";
+import type { Subtitle } from "../types/subtitle";
+
+let uuidCounter = 0;
+const nextUuid = () => {
+  uuidCounter += 1;
+  return `quality-${uuidCounter}`;
+};
+
+const makeSubtitle = (overrides: Partial<Subtitle>): Subtitle => ({
+  uuid: overrides.uuid ?? nextUuid(),
+  id: overrides.id ?? 1,
+  startTime: overrides.startTime ?? "00:00:00,000",
+  endTime: overrides.endTime ?? "00:00:02,000",
+  text: overrides.text ?? "Sample subtitle",
+  trackId: overrides.trackId,
+});
+
+const ruleIds = (issues: ReturnType<typeof analyzeSubtitleQuality>) =>
+  new Set<SubtitleQualityRuleId>(issues.map((issue) => issue.ruleId));
+
+test("analyzeSubtitleQuality reports the focused text and tag rule set", () => {
+  const issues = analyzeSubtitleQuality(
+    [
+      makeSubtitle({ uuid: "empty", id: 1, text: "   " }),
+      makeSubtitle({ uuid: "space", id: 2, text: "  Hello   world  " }),
+      makeSubtitle({ uuid: "word", id: 3, text: "This is is repeated" }),
+      makeSubtitle({
+        uuid: "long-line",
+        id: 4,
+        text: "This line is too long for this test threshold",
+      }),
+      makeSubtitle({ uuid: "many-lines", id: 5, text: "one\ntwo\nthree" }),
+      makeSubtitle({ uuid: "tags", id: 6, text: "<i>italic" }),
+    ],
+    {
+      maxCharactersPerLine: 12,
+      maxLinesPerCue: 2,
+    },
+  );
+
+  const detectedRuleIds = ruleIds(issues);
+  assert.equal(detectedRuleIds.has("empty-cue"), true);
+  assert.equal(detectedRuleIds.has("trim-whitespace"), true);
+  assert.equal(detectedRuleIds.has("repeated-whitespace"), true);
+  assert.equal(detectedRuleIds.has("repeated-word"), true);
+  assert.equal(detectedRuleIds.has("line-length"), true);
+  assert.equal(detectedRuleIds.has("line-count"), true);
+  assert.equal(detectedRuleIds.has("unbalanced-tags"), true);
+
+  const tagIssue = issues.find((issue) => issue.ruleId === "unbalanced-tags");
+  assert.equal(tagIssue?.fix, undefined);
+});
+
+test("applySubtitleQualityFixes applies selected text fixes sequentially", () => {
+  const subtitles = [
+    makeSubtitle({
+      uuid: "cleanup",
+      id: 1,
+      text: "  the   the  quick  ",
+    }),
+  ];
+  const issues = analyzeSubtitleQuality(subtitles);
+
+  const result = applySubtitleQualityFixes(
+    subtitles,
+    issues.filter((issue) => issue.fix),
+  );
+
+  assert.deepEqual(result.appliedIssueIds, [
+    "trim-whitespace:cleanup",
+    "repeated-whitespace:cleanup",
+    "repeated-word:cleanup",
+  ]);
+  assert.equal(result.subtitles[0].text, "the quick");
+  assert.equal(result.subtitles[0].uuid, "cleanup");
+  assert.equal(result.subtitles[0].id, 1);
+});
+
+test("applySubtitleQualityFixes deletes empty cues and renumbers remaining cues", () => {
+  const subtitles = [
+    makeSubtitle({ uuid: "keep-1", id: 1, text: "Keep" }),
+    makeSubtitle({ uuid: "remove", id: 2, text: "  " }),
+    makeSubtitle({ uuid: "keep-2", id: 3, text: "Also keep" }),
+  ];
+  const issues = analyzeSubtitleQuality(subtitles);
+
+  const result = applySubtitleQualityFixes(
+    subtitles,
+    issues.filter((issue) => issue.ruleId === "empty-cue"),
+  );
+
+  assert.deepEqual(
+    result.subtitles.map((subtitle) => subtitle.uuid),
+    ["keep-1", "keep-2"],
+  );
+  assert.deepEqual(
+    result.subtitles.map((subtitle) => subtitle.id),
+    [1, 2],
+  );
+});
+
+test("applySubtitleQualityFixes applies timing fixes for invalid durations, overlaps, and thresholds", () => {
+  const subtitles = [
+    makeSubtitle({
+      uuid: "first",
+      id: 1,
+      startTime: "00:00:00,000",
+      endTime: "00:00:02,000",
+      text: "First",
+    }),
+    makeSubtitle({
+      uuid: "overlap",
+      id: 2,
+      startTime: "00:00:01,500",
+      endTime: "00:00:03,000",
+      text: "Overlap",
+    }),
+    makeSubtitle({
+      uuid: "invalid",
+      id: 3,
+      startTime: "00:00:04,000",
+      endTime: "00:00:04,000",
+      text: "Invalid",
+    }),
+    makeSubtitle({
+      uuid: "short",
+      id: 4,
+      startTime: "00:00:05,000",
+      endTime: "00:00:05,500",
+      text: "Short",
+    }),
+    makeSubtitle({
+      uuid: "long",
+      id: 5,
+      startTime: "00:00:07,000",
+      endTime: "00:00:20,000",
+      text: "Long",
+    }),
+  ];
+  const options = {
+    minDurationSeconds: 1,
+    maxDurationSeconds: 7,
+  };
+  const issues = analyzeSubtitleQuality(subtitles, options);
+
+  const result = applySubtitleQualityFixes(
+    subtitles,
+    issues.filter((issue) => issue.fix),
+    options,
+  );
+
+  assert.equal(result.subtitles[1].startTime, "00:00:02,000");
+  assert.equal(result.subtitles[1].endTime, "00:00:03,000");
+  assert.equal(result.subtitles[2].startTime, "00:00:04,000");
+  assert.equal(result.subtitles[2].endTime, "00:00:05,000");
+  assert.equal(result.subtitles[3].startTime, "00:00:05,000");
+  assert.equal(result.subtitles[3].endTime, "00:00:06,000");
+  assert.equal(result.subtitles[4].startTime, "00:00:07,000");
+  assert.equal(result.subtitles[4].endTime, "00:00:14,000");
+});
+
+test("line length and line count fixes produce bounded preview text", () => {
+  const subtitles = [
+    makeSubtitle({
+      uuid: "line-length",
+      id: 1,
+      text: "alpha beta gamma delta",
+    }),
+    makeSubtitle({
+      uuid: "line-count",
+      id: 2,
+      text: "one\ntwo\nthree\nfour",
+    }),
+  ];
+  const options = {
+    maxCharactersPerLine: 11,
+    maxLinesPerCue: 2,
+  };
+  const issues = analyzeSubtitleQuality(subtitles, options);
+
+  const result = applySubtitleQualityFixes(
+    subtitles,
+    issues.filter((issue) => issue.fix),
+    options,
+  );
+
+  assert.deepEqual(result.subtitles[0].text.split("\n"), [
+    "alpha beta",
+    "gamma delta",
+  ]);
+  assert.equal(result.subtitles[1].text.split("\n").length <= 2, true);
+});


### PR DESCRIPTION
## Summary

- Adds a browser-only subtitle QA engine for common cleanup issues.
- Adds a compact header-launched QA dialog with severity/rule filters, threshold controls, previews, and selected automatic fixes.
- Wires fixes through the existing active-track `replaceAllSubtitlesAction` path so one apply operation remains undoable.
- Adds English, German, and Cantonese UI strings plus rule coverage in `tests/subtitle-quality.test.ts`.

Closes #33.

## Validation

- `npm run lint`
- `npm test` (55 passing tests)
- `npm run build`

## Notes

- The local `.codex/` environment file is intentionally not included.
- The QA tool stays scoped to the active track and browser-only deterministic subtitle data logic.
