### PR TITLE
[codex] Add main subtitle list multi-select

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -19,6 +19,7 @@ import {
   SubtitleProvider,
   useSubtitleActionsContext,
   useSubtitleHistory,
+  useSubtitleSelection,
   useSubtitleState,
   useSubtitles,
 } from "@/context/subtitle-context";
@@ -38,7 +39,7 @@ import type {
   ForwardRefExoticComponent,
   RefAttributes,
 } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 
 const VideoPlayer = dynamic<VideoPlayerProps>(
@@ -92,6 +93,7 @@ function MainContent() {
   } = useSubtitleActionsContext();
   const { undoSubtitles, redoSubtitles, canUndoSubtitles, canRedoSubtitles } =
     useSubtitleHistory();
+  const { selectedSubtitleUuids } = useSubtitleSelection();
   // Keep page-specific state here
 
   const [mediaFile, setMediaFile] = useState<File | null>(null);
@@ -133,6 +135,10 @@ function MainContent() {
   const activeTrackSubtitles = activeTrack?.subtitles ?? [];
   const allowSubtitleDrop = tracks.length === 0 || activeTrackIsEmpty;
   const bulkOffsetDisabled = !activeTrack || activeTrackSubtitles.length === 0;
+  const initialBulkOffsetSelection = useMemo(
+    () => Array.from(selectedSubtitleUuids),
+    [selectedSubtitleUuids],
+  );
   const loadMediaFile = (file: File) => {
     setMediaFile(null);
     if (mediaFileInputRef.current) {
@@ -423,6 +429,7 @@ function MainContent() {
                 subtitles={activeTrackSubtitles}
                 trackIndex={activeTrackIndex}
                 currentTrackName={activeTrack?.name ?? null}
+                initialSelectedUuids={initialBulkOffsetSelection}
                 onPreviewChange={setBulkOffsetPreview}
                 onApplyOffset={(selection, offsetSeconds, target) => {
                   bulkShiftSubtitlesAction(selection, offsetSeconds, target);

--- a/components/bulk-offset/drawer.tsx
+++ b/components/bulk-offset/drawer.tsx
@@ -21,6 +21,7 @@ export interface BulkOffsetDrawerProps {
   subtitles: Subtitle[];
   trackIndex: number;
   currentTrackName?: string | null;
+  initialSelectedUuids?: string[];
   onPreviewChange?: (preview: Record<string, BulkOffsetPreviewState>) => void;
   onApplyOffset: (
     selectedUuids: string[],
@@ -34,6 +35,7 @@ export function BulkOffsetDrawer({
   subtitles,
   trackIndex,
   currentTrackName,
+  initialSelectedUuids,
   onPreviewChange,
   onApplyOffset,
 }: BulkOffsetDrawerProps) {
@@ -42,6 +44,7 @@ export function BulkOffsetDrawer({
   const [selectedUuids, setSelectedUuids] = useState<Set<string>>(new Set());
   const [shiftTarget, setShiftTarget] = useState<BulkShiftTarget>("both");
   const lastInteractedIndexRef = useRef<number | null>(null);
+  const hasInitializedSelectionRef = useRef(false);
   const normalizedTrackIndex = trackIndex >= 0 ? trackIndex : 0;
   const trackHandleColor = getTrackHandleColor(normalizedTrackIndex);
   const trackBackgroundColor = getTrackColor(normalizedTrackIndex);
@@ -53,20 +56,32 @@ export function BulkOffsetDrawer({
 
   useEffect(() => {
     if (!isOpen) {
+      hasInitializedSelectionRef.current = false;
       return;
     }
     const available = new Set(subtitles.map((subtitle) => subtitle.uuid));
+    if (!hasInitializedSelectionRef.current) {
+      const initialSelection = (initialSelectedUuids ?? []).filter((uuid) =>
+        available.has(uuid),
+      );
+      const nextSelection =
+        initialSelection.length > 0
+          ? new Set(initialSelection)
+          : new Set(available);
+      setSelectedUuids(nextSelection);
+      const lastSelectedUuid = Array.from(nextSelection).at(-1);
+      lastInteractedIndexRef.current = lastSelectedUuid
+        ? subtitles.findIndex((subtitle) => subtitle.uuid === lastSelectedUuid)
+        : null;
+      hasInitializedSelectionRef.current = true;
+      return;
+    }
+
     setSelectedUuids((prev) => {
-      if (prev.size === 0) {
-        return available;
-      }
       const filtered = new Set([...prev].filter((uuid) => available.has(uuid)));
-      if (filtered.size === 0) {
-        return available;
-      }
       return filtered;
     });
-  }, [isOpen, subtitles]);
+  }, [initialSelectedUuids, isOpen, subtitles]);
 
   useEffect(() => {
     if (isOpen) {

--- a/components/subtitle/subtitle-item-delete-button.tsx
+++ b/components/subtitle/subtitle-item-delete-button.tsx
@@ -1,4 +1,8 @@
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { IconTrash } from "@tabler/icons-react";
 import { useTranslations } from "next-intl";
 
@@ -15,7 +19,11 @@ export default function SubtitleItemDeleteButton({
     <Tooltip>
       <TooltipTrigger
         type="button"
-        onClick={onDelete}
+        onPointerDown={(event) => event.stopPropagation()}
+        onClick={(event) => {
+          event.stopPropagation();
+          onDelete();
+        }}
         className="mx-4 my-auto px-2 py-1 text-sm rounded bg-red-300 hover:bg-red-400 text-red-800 dark:bg-red-800 dark:hover:bg-red-900 dark:text-red-300 cursor-pointer"
         aria-label={t("tooltips.delete")}
       >

--- a/components/subtitle/subtitle-item-text-editor.tsx
+++ b/components/subtitle/subtitle-item-text-editor.tsx
@@ -154,12 +154,7 @@ export default function SubtitleTextEditor({
             const nextText = e.currentTarget.value;
 
             if (e.shiftKey) {
-              onSplitSubtitle(
-                subtitle.id,
-                caretPos,
-                nextText.length,
-                nextText,
-              );
+              onSplitSubtitle(subtitle.id, caretPos, nextText.length, nextText);
             } else if (nextText !== subtitle.text) {
               onUpdateText(subtitle.id, nextText);
             }
@@ -186,6 +181,9 @@ export default function SubtitleTextEditor({
           : "Edit subtitle (empty)"
       }
       onClick={(event) => {
+        if (event.metaKey || event.ctrlKey || event.shiftKey) {
+          return;
+        }
         if (event.detail === 0) {
           event.stopPropagation();
           event.preventDefault();
@@ -193,6 +191,9 @@ export default function SubtitleTextEditor({
         setEditingSubtitleUuid(subtitle.uuid);
       }}
       onKeyUp={(event) => {
+        if (event.metaKey || event.ctrlKey || event.shiftKey) {
+          return;
+        }
         if (event.key === "Enter" || event.key === " ") {
           event.preventDefault();
           event.stopPropagation();
@@ -200,9 +201,7 @@ export default function SubtitleTextEditor({
         }
       }}
     >
-      {subtitle.text || (
-        <span className="text-muted-foreground">(Empty)</span>
-      )}
+      {subtitle.text || <span className="text-muted-foreground">(Empty)</span>}
     </button>
   );
 }

--- a/components/subtitle/subtitle-item.tsx
+++ b/components/subtitle/subtitle-item.tsx
@@ -4,7 +4,7 @@ import {
   useSubtitleState,
   useSubtitleTimings,
 } from "@/context/subtitle-context";
-import { timeToSeconds } from "@/lib/utils";
+import { cn, timeToSeconds } from "@/lib/utils";
 import type { Subtitle } from "@/types/subtitle";
 import { motion } from "motion/react";
 import { useTranslations } from "next-intl";
@@ -20,8 +20,13 @@ interface SubtitleItemProps {
   previousSubtitle: Subtitle | null;
   isLastItem: boolean;
   currentTime: number;
+  isSelected: boolean;
   editingSubtitleUuid: string | null;
   onScrollToRegion: (uuid: string) => void;
+  onSelectSubtitle: (
+    uuid: string,
+    event: React.MouseEvent<HTMLDivElement>,
+  ) => void;
   isPlaying: boolean;
   resumePlayback: () => void;
   setIsPlaying: React.Dispatch<React.SetStateAction<boolean>>;
@@ -36,8 +41,10 @@ const SubtitleItem = memo(function SubtitleItem({
   previousSubtitle,
   isLastItem,
   currentTime,
+  isSelected,
   editingSubtitleUuid,
   onScrollToRegion,
+  onSelectSubtitle,
   isPlaying,
   resumePlayback,
   setIsPlaying,
@@ -85,6 +92,7 @@ const SubtitleItem = memo(function SubtitleItem({
   const characterCount = Array.from(subtitle.text).length;
 
   const isEditing = editingSubtitleUuid === subtitle.uuid;
+  const isCurrentCue = startSeconds <= currentTime && endSeconds > currentTime;
 
   return (
     <motion.div
@@ -98,9 +106,11 @@ const SubtitleItem = memo(function SubtitleItem({
         {/* biome-ignore lint/a11y/noStaticElementInteractions: Interactive div */}
         <div
           id={`subtitle-${subtitle.uuid}`}
+          role="option"
           tabIndex={-1}
           onPointerDown={() => onPrepareSubtitleInteraction(subtitle.uuid)}
-          onClick={() => onScrollToRegion(subtitle.uuid)}
+          aria-selected={isSelected}
+          onClick={(event) => onSelectSubtitle(subtitle.uuid, event)}
           onFocus={() => {
             if (isPlaying) {
               return;
@@ -115,15 +125,18 @@ const SubtitleItem = memo(function SubtitleItem({
               resumePlayback();
             }
           }}
-          className={`px-4 py-2 border-b border-black dark:border-white hover:bg-yellow-200 cursor-pointer grid gap-4 items-center ${
-            startSeconds <= currentTime && endSeconds > currentTime
-              ? "bg-sky-400"
-              : ""
-          } ${
+          className={cn(
+            "px-4 py-2 border-b border-black dark:border-white hover:bg-yellow-200 cursor-pointer grid gap-4 items-center",
+            isCurrentCue && "bg-sky-400 dark:bg-sky-700",
+            isSelected &&
+              "bg-yellow-100 ring-2 ring-inset ring-yellow-500 dark:bg-yellow-900/40",
+            isCurrentCue &&
+              isSelected &&
+              "bg-sky-300 ring-2 ring-inset ring-yellow-500 dark:bg-sky-800",
             showSubtitleDuration
               ? "grid-cols-[1rem_7rem_5rem_1fr]"
-              : "grid-cols-[1rem_7rem_1fr]"
-          }`}
+              : "grid-cols-[1rem_7rem_1fr]",
+          )}
         >
           <div className="text-sm font-mono">{subtitle.id}</div>
 

--- a/components/subtitle/subtitle-list.tsx
+++ b/components/subtitle/subtitle-list.tsx
@@ -1,5 +1,6 @@
 import {
   useSubtitleActionsContext,
+  useSubtitleSelection,
   useSubtitles,
   useSubtitleState,
   useSubtitleTimings,
@@ -68,7 +69,13 @@ const SubtitleList = forwardRef<SubtitleListRef, SubtitleListProps>(
       loadSubtitlesIntoTrack,
       renameTrack,
       deleteSubtitleAction,
+      deleteSubtitlesByUuidAction,
     } = useSubtitleActionsContext();
+    const {
+      selectedSubtitleUuids,
+      selectSubtitleWithModifiers,
+      clearSubtitleSelection,
+    } = useSubtitleSelection();
     const { activeTrackId } = useSubtitleState();
     const { list: subtitleTimings } = useSubtitleTimings();
 
@@ -93,6 +100,9 @@ const SubtitleList = forwardRef<SubtitleListRef, SubtitleListProps>(
       setPlaybackTime,
       mergeSubtitlesAction,
       deleteSubtitleAction,
+      deleteSubtitlesByUuidAction,
+      selectedSubtitleUuids,
+      clearSubtitleSelection,
       manualScrollRequestUuidRef,
     });
 
@@ -190,8 +200,16 @@ const SubtitleList = forwardRef<SubtitleListRef, SubtitleListProps>(
       suppressAutoCenterUuidRef.current = uuid;
     };
 
-    const handleSubtitleItemClick = (uuid: string) => {
+    const handleSubtitleItemClick = (
+      uuid: string,
+      event: React.MouseEvent<HTMLDivElement>,
+    ) => {
       suppressAutoCenterUuidRef.current = uuid;
+      selectSubtitleWithModifiers(uuid, {
+        shiftKey: event.shiftKey,
+        metaKey: event.metaKey,
+        ctrlKey: event.ctrlKey,
+      });
       onScrollToRegion(uuid);
     };
 
@@ -205,7 +223,12 @@ const SubtitleList = forwardRef<SubtitleListRef, SubtitleListProps>(
     }
 
     return (
-      <div ref={listRef} className="h-full overflow-y-scroll">
+      <div
+        ref={listRef}
+        className="h-full overflow-y-scroll"
+        role="listbox"
+        aria-multiselectable="true"
+      >
         <AnimatePresence>
           {subtitles.map((subtitle: Subtitle, index: number) => {
             const isLastItem = index === subtitles.length - 1;
@@ -220,8 +243,10 @@ const SubtitleList = forwardRef<SubtitleListRef, SubtitleListProps>(
                 isLastItem={isLastItem}
                 currentTime={currentTime}
                 isPlaying={isPlaying}
+                isSelected={selectedSubtitleUuids.has(subtitle.uuid)}
                 editingSubtitleUuid={editingSubtitleUuid}
-                onScrollToRegion={handleSubtitleItemClick}
+                onScrollToRegion={onScrollToRegion}
+                onSelectSubtitle={handleSubtitleItemClick}
                 onPrepareSubtitleInteraction={prepareSubtitleInteraction}
                 setEditingSubtitleUuid={setEditingSubtitleUuid}
                 resumePlayback={resumePlayback}

--- a/components/subtitle/use-subtitle-list-shortcuts.ts
+++ b/components/subtitle/use-subtitle-list-shortcuts.ts
@@ -12,6 +12,9 @@ interface SubtitleListShortcutsOptions {
   setPlaybackTime: (time: number) => void;
   mergeSubtitlesAction: (previousId: number, currentId: number) => void;
   deleteSubtitleAction: (id: number) => void;
+  deleteSubtitlesByUuidAction: (uuids: string[]) => void;
+  selectedSubtitleUuids: Set<string>;
+  clearSubtitleSelection: () => void;
   manualScrollRequestUuidRef: React.MutableRefObject<string | null>;
 }
 
@@ -24,6 +27,9 @@ export function useSubtitleListShortcuts({
   setPlaybackTime,
   mergeSubtitlesAction,
   deleteSubtitleAction,
+  deleteSubtitlesByUuidAction,
+  selectedSubtitleUuids,
+  clearSubtitleSelection,
   manualScrollRequestUuidRef,
 }: SubtitleListShortcutsOptions) {
   useEffect(() => {
@@ -51,6 +57,12 @@ export function useSubtitleListShortcuts({
       }
 
       if (isEditing) {
+        return;
+      }
+
+      if (event.key === "Escape" && selectedSubtitleUuids.size > 0) {
+        event.preventDefault();
+        clearSubtitleSelection();
         return;
       }
 
@@ -106,6 +118,36 @@ export function useSubtitleListShortcuts({
       if (event.key === "Delete") {
         event.preventDefault();
 
+        if (selectedSubtitleUuids.size > 0) {
+          const firstSelectedIndex = subtitles.findIndex((subtitle) =>
+            selectedSubtitleUuids.has(subtitle.uuid),
+          );
+          const nextSubtitle = subtitles.find(
+            (subtitle, index) =>
+              index >= firstSelectedIndex &&
+              !selectedSubtitleUuids.has(subtitle.uuid),
+          );
+          const previousSubtitle =
+            firstSelectedIndex > 0
+              ? subtitles
+                  .slice(0, firstSelectedIndex)
+                  .findLast(
+                    (subtitle) => !selectedSubtitleUuids.has(subtitle.uuid),
+                  )
+              : undefined;
+
+          deleteSubtitlesByUuidAction(Array.from(selectedSubtitleUuids));
+          clearSubtitleSelection();
+
+          const targetSubtitle = nextSubtitle ?? previousSubtitle;
+          if (targetSubtitle) {
+            setPlaybackTime(timeToSeconds(targetSubtitle.startTime));
+          } else {
+            setPlaybackTime(0);
+          }
+          return;
+        }
+
         let currentIndex = subtitleTimings.findIndex(
           (timing) => timing.start <= currentTime && timing.end > currentTime,
         );
@@ -152,6 +194,9 @@ export function useSubtitleListShortcuts({
     onTimeJump,
     jumpDuration,
     deleteSubtitleAction,
+    deleteSubtitlesByUuidAction,
+    selectedSubtitleUuids,
+    clearSubtitleSelection,
     manualScrollRequestUuidRef,
   ]);
 }

--- a/context/subtitle-context.tsx
+++ b/context/subtitle-context.tsx
@@ -22,6 +22,12 @@ import {
   type LocalSessionPreferences,
   type LocalSessionSnapshot,
 } from "@/lib/local-session";
+import {
+  applySubtitleSelectionInteraction,
+  pruneSubtitleSelection,
+  type SubtitleSelectionModifiers,
+  type SubtitleSelectionState,
+} from "@/lib/subtitle-selection";
 import { timeToSeconds } from "@/lib/utils";
 import type { Subtitle, SubtitleTrack } from "@/types/subtitle";
 import React, {
@@ -62,11 +68,21 @@ interface SubtitleHistoryValue {
   canRedoSubtitles: boolean;
 }
 
+interface SubtitleSelectionValue {
+  selectedSubtitleUuids: Set<string>;
+  selectionAnchorUuid: string | null;
+  selectSubtitleWithModifiers: (
+    uuid: string,
+    modifiers?: SubtitleSelectionModifiers,
+  ) => void;
+  clearSubtitleSelection: () => void;
+}
+
 type SubtitleContextType = SubtitleStateValue &
   SubtitleActions &
   SubtitleHistoryValue & {
     subtitles: Subtitle[];
-  };
+  } & SubtitleSelectionValue;
 
 interface LocalSessionValue {
   pendingLocalSession: LocalSessionSnapshot | null;
@@ -74,9 +90,7 @@ interface LocalSessionValue {
   restoreLocalSession: () => void;
   discardLocalSession: () => void;
   clearLocalSession: () => void;
-  downloadLocalSessionBackup: (
-    snapshot?: LocalSessionSnapshot | null,
-  ) => void;
+  downloadLocalSessionBackup: (snapshot?: LocalSessionSnapshot | null) => void;
 }
 
 interface SubtitleTimingEntry {
@@ -106,6 +120,9 @@ const SubtitleTimingContext = createContext<SubtitleTimingState | undefined>(
 const LocalSessionContext = createContext<LocalSessionValue | undefined>(
   undefined,
 );
+const SubtitleSelectionContext = createContext<
+  SubtitleSelectionValue | undefined
+>(undefined);
 
 interface SubtitleProviderProps {
   children: ReactNode;
@@ -137,6 +154,11 @@ export function SubtitleProvider({ children }: SubtitleProviderProps) {
   const [hasLocalSession, setHasLocalSession] = useState(
     () => readRecoverableLocalSession() !== null,
   );
+  const [subtitleSelection, setSubtitleSelection] =
+    useState<SubtitleSelectionState>({
+      selectedUuids: new Set(),
+      anchorUuid: null,
+    });
   const previousActiveTrackId = useRef<string | null>(null);
   const suppressedAutosaveFingerprintRef = useRef<string | null>(null);
   const trackHistoriesRef = useRef<Map<string, UndoHistory<Subtitle[]>>>(
@@ -275,7 +297,8 @@ export function SubtitleProvider({ children }: SubtitleProviderProps) {
 
   const downloadLocalSessionBackup = useCallback(
     (snapshot?: LocalSessionSnapshot | null) => {
-      const session = snapshot ?? pendingLocalSession ?? createCurrentLocalSession();
+      const session =
+        snapshot ?? pendingLocalSession ?? createCurrentLocalSession();
       if (!session || !shouldAutosaveLocalSession(session)) {
         return;
       }
@@ -362,6 +385,33 @@ export function SubtitleProvider({ children }: SubtitleProviderProps) {
     });
   }, [activeTrackId, activeSubtitles]);
 
+  useEffect(() => {
+    setSubtitleSelection((prev) => {
+      if (prev.selectedUuids.size === 0 && prev.anchorUuid === null) {
+        return prev;
+      }
+      return { selectedUuids: new Set(), anchorUuid: null };
+    });
+  }, [activeTrackId]);
+
+  useEffect(() => {
+    const orderedUuids = activeSubtitles.map((subtitle) => subtitle.uuid);
+    setSubtitleSelection((prev) => {
+      const pruned = pruneSubtitleSelection(
+        prev.selectedUuids,
+        prev.anchorUuid,
+        orderedUuids,
+      );
+      if (
+        pruned.selectedUuids === prev.selectedUuids &&
+        pruned.anchorUuid === prev.anchorUuid
+      ) {
+        return prev;
+      }
+      return pruned;
+    });
+  }, [activeSubtitles]);
+
   const subtitleActions = useSubtitleActions({
     tracks,
     activeTrackId,
@@ -441,6 +491,41 @@ export function SubtitleProvider({ children }: SubtitleProviderProps) {
     [undoSubtitles, redoSubtitles, canUndoSubtitles, canRedoSubtitles],
   );
 
+  const clearSubtitleSelection = useCallback(() => {
+    setSubtitleSelection((prev) => {
+      if (prev.selectedUuids.size === 0 && prev.anchorUuid === null) {
+        return prev;
+      }
+      return { selectedUuids: new Set(), anchorUuid: null };
+    });
+  }, []);
+
+  const selectSubtitleWithModifiers = useCallback(
+    (uuid: string, modifiers?: SubtitleSelectionModifiers) => {
+      const orderedUuids = activeSubtitles.map((subtitle) => subtitle.uuid);
+      setSubtitleSelection((prev) =>
+        applySubtitleSelectionInteraction({
+          orderedUuids,
+          selectedUuids: prev.selectedUuids,
+          anchorUuid: prev.anchorUuid,
+          targetUuid: uuid,
+          modifiers,
+        }),
+      );
+    },
+    [activeSubtitles],
+  );
+
+  const selectionValue = useMemo<SubtitleSelectionValue>(
+    () => ({
+      selectedSubtitleUuids: subtitleSelection.selectedUuids,
+      selectionAnchorUuid: subtitleSelection.anchorUuid,
+      selectSubtitleWithModifiers,
+      clearSubtitleSelection,
+    }),
+    [subtitleSelection, selectSubtitleWithModifiers, clearSubtitleSelection],
+  );
+
   const timingState = useMemo<SubtitleTimingState>(() => {
     const list = activeSubtitles.map((subtitle) => ({
       uuid: subtitle.uuid,
@@ -475,11 +560,13 @@ export function SubtitleProvider({ children }: SubtitleProviderProps) {
       <SubtitleActionsContext.Provider value={subtitleActions}>
         <SubtitleHistoryContext.Provider value={historyValue}>
           <SubtitleStateContext.Provider value={stateValue}>
-            <SubtitleTimingContext.Provider value={timingState}>
-              <SubtitleDataContext.Provider value={activeSubtitles}>
-                {children}
-              </SubtitleDataContext.Provider>
-            </SubtitleTimingContext.Provider>
+            <SubtitleSelectionContext.Provider value={selectionValue}>
+              <SubtitleTimingContext.Provider value={timingState}>
+                <SubtitleDataContext.Provider value={activeSubtitles}>
+                  {children}
+                </SubtitleDataContext.Provider>
+              </SubtitleTimingContext.Provider>
+            </SubtitleSelectionContext.Provider>
           </SubtitleStateContext.Provider>
         </SubtitleHistoryContext.Provider>
       </SubtitleActionsContext.Provider>
@@ -524,11 +611,17 @@ export const useSubtitleTimings = (): SubtitleTimingState => {
   return ensureContext(ctx, "useSubtitleTimings");
 };
 
+export const useSubtitleSelection = (): SubtitleSelectionValue => {
+  const ctx = useContext(SubtitleSelectionContext);
+  return ensureContext(ctx, "useSubtitleSelection");
+};
+
 export const useSubtitleContext = (): SubtitleContextType => {
   const state = useSubtitleState();
   const actions = useSubtitleActionsContext();
   const history = useSubtitleHistory();
   const subtitles = useSubtitles();
+  const selection = useSubtitleSelection();
 
   return useMemo(
     () => ({
@@ -536,7 +629,8 @@ export const useSubtitleContext = (): SubtitleContextType => {
       ...actions,
       ...history,
       subtitles,
+      ...selection,
     }),
-    [actions, history, state, subtitles],
+    [actions, history, state, subtitles, selection],
   );
 };

--- a/hooks/use-subtitle-actions.ts
+++ b/hooks/use-subtitle-actions.ts
@@ -6,6 +6,7 @@ import type { UndoHistory } from "@/hooks/use-undoable-state";
 import {
   addSubtitle,
   deleteSubtitle,
+  deleteSubtitlesByUuid,
   mergeSubtitles,
   splitSubtitle,
   updateSubtitle,
@@ -59,6 +60,7 @@ export interface SubtitleActions {
     newSubtitleText?: string,
   ) => void;
   deleteSubtitleAction: (id: number) => void;
+  deleteSubtitlesByUuidAction: (uuids: string[]) => void;
   mergeSubtitlesAction: (id1: number, id2: number) => void;
   splitSubtitleAction: (
     id: number,
@@ -231,6 +233,10 @@ export const useSubtitleActions = ({
 
     const deleteSubtitleAction = (id: number) => {
       handleTrackedStateChange(deleteSubtitle(activeSubtitles, id));
+    };
+
+    const deleteSubtitlesByUuidAction = (uuids: string[]) => {
+      handleTrackedStateChange(deleteSubtitlesByUuid(activeSubtitles, uuids));
     };
 
     const mergeSubtitlesAction = (id1: number, id2: number) => {
@@ -450,6 +456,7 @@ export const useSubtitleActions = ({
       setInitialSubtitles,
       addSubtitleAction,
       deleteSubtitleAction,
+      deleteSubtitlesByUuidAction,
       mergeSubtitlesAction,
       splitSubtitleAction,
       updateSubtitleTextAction,

--- a/lib/subtitle-operations.ts
+++ b/lib/subtitle-operations.ts
@@ -300,6 +300,25 @@ export const deleteSubtitle = (
   return reorderSubtitleIds(updatedSubtitles);
 };
 
+export const deleteSubtitlesByUuid = (
+  subtitles: Subtitle[],
+  uuids: readonly string[],
+): Subtitle[] => {
+  const targetUuids = new Set(uuids);
+  if (targetUuids.size === 0) {
+    return subtitles;
+  }
+
+  const updatedSubtitles = subtitles.filter(
+    (sub) => !targetUuids.has(sub.uuid),
+  );
+  if (updatedSubtitles.length === subtitles.length) {
+    return subtitles;
+  }
+
+  return reorderSubtitleIds(updatedSubtitles);
+};
+
 export const addSubtitle = (
   subtitles: Subtitle[],
   beforeId: number,

--- a/lib/subtitle-selection.ts
+++ b/lib/subtitle-selection.ts
@@ -1,0 +1,89 @@
+export interface SubtitleSelectionState {
+  selectedUuids: Set<string>;
+  anchorUuid: string | null;
+}
+
+export interface SubtitleSelectionModifiers {
+  shiftKey?: boolean;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+}
+
+interface ApplySubtitleSelectionOptions {
+  orderedUuids: readonly string[];
+  selectedUuids: Set<string>;
+  anchorUuid: string | null;
+  targetUuid: string;
+  modifiers?: SubtitleSelectionModifiers;
+}
+
+export function applySubtitleSelectionInteraction({
+  orderedUuids,
+  selectedUuids,
+  anchorUuid,
+  targetUuid,
+  modifiers,
+}: ApplySubtitleSelectionOptions): SubtitleSelectionState {
+  if (!orderedUuids.includes(targetUuid)) {
+    return { selectedUuids, anchorUuid };
+  }
+
+  if (modifiers?.shiftKey) {
+    const effectiveAnchor =
+      anchorUuid && orderedUuids.includes(anchorUuid) ? anchorUuid : targetUuid;
+    const anchorIndex = orderedUuids.indexOf(effectiveAnchor);
+    const targetIndex = orderedUuids.indexOf(targetUuid);
+    const start = Math.min(anchorIndex, targetIndex);
+    const end = Math.max(anchorIndex, targetIndex);
+
+    return {
+      selectedUuids: new Set(orderedUuids.slice(start, end + 1)),
+      anchorUuid: effectiveAnchor,
+    };
+  }
+
+  if (modifiers?.metaKey || modifiers?.ctrlKey) {
+    const next = new Set(selectedUuids);
+    if (next.has(targetUuid)) {
+      next.delete(targetUuid);
+    } else {
+      next.add(targetUuid);
+    }
+
+    return {
+      selectedUuids: next,
+      anchorUuid: targetUuid,
+    };
+  }
+
+  return {
+    selectedUuids: new Set([targetUuid]),
+    anchorUuid: targetUuid,
+  };
+}
+
+export function pruneSubtitleSelection(
+  selectedUuids: Set<string>,
+  anchorUuid: string | null,
+  allowedUuids: readonly string[],
+): SubtitleSelectionState {
+  const allowed = new Set(allowedUuids);
+  let changed = false;
+  const next = new Set<string>();
+
+  selectedUuids.forEach((uuid) => {
+    if (allowed.has(uuid)) {
+      next.add(uuid);
+    } else {
+      changed = true;
+    }
+  });
+
+  const nextAnchorUuid =
+    anchorUuid && allowed.has(anchorUuid) ? anchorUuid : null;
+
+  return {
+    selectedUuids: changed ? next : selectedUuids,
+    anchorUuid: nextAnchorUuid,
+  };
+}

--- a/tests/subtitle-context.test.ts
+++ b/tests/subtitle-context.test.ts
@@ -98,6 +98,17 @@ test.afterEach(() => {
   cleanup();
 });
 
+const threeSubtitles = [
+  ...baseSubtitles,
+  {
+    uuid: "base-3",
+    id: 3,
+    startTime: "00:00:07,000",
+    endTime: "00:00:09,000",
+    text: "You are a bold one",
+  },
+];
+
 test("subtitle actions push history and support undo/redo cycles", async () => {
   const { result } = renderHook(() => useSubtitleContext(), { wrapper });
 
@@ -250,6 +261,118 @@ test("undo stacks remain isolated per track when switching focus", async () => {
     assert.equal(result.current.activeTrackId, trackB);
   });
   assert.equal(result.current.subtitles[0].text, "Second track line");
+});
+
+test("deleteSubtitlesByUuidAction removes selected cues in one undo step", async () => {
+  const { result } = renderHook(() => useSubtitleContext(), { wrapper });
+
+  await act(async () => {
+    result.current.setInitialSubtitles([...threeSubtitles], "Track Delete");
+  });
+
+  await waitFor(() => {
+    assert.equal(result.current.subtitles.length, 3);
+  });
+
+  await act(async () => {
+    result.current.selectSubtitleWithModifiers("base-1");
+    result.current.selectSubtitleWithModifiers("base-3", { ctrlKey: true });
+  });
+
+  assert.deepEqual(Array.from(result.current.selectedSubtitleUuids), [
+    "base-1",
+    "base-3",
+  ]);
+
+  await act(async () => {
+    result.current.deleteSubtitlesByUuidAction(
+      Array.from(result.current.selectedSubtitleUuids),
+    );
+  });
+
+  await waitFor(() => {
+    assert.equal(result.current.subtitles.length, 1);
+  });
+
+  assert.equal(result.current.subtitles[0].uuid, "base-2");
+  assert.equal(result.current.subtitles[0].id, 1);
+
+  await waitFor(() => {
+    assert.equal(result.current.selectedSubtitleUuids.size, 0);
+  });
+
+  await act(async () => {
+    result.current.undoSubtitles();
+  });
+
+  assert.deepEqual(
+    result.current.subtitles.map((subtitle) => subtitle.uuid),
+    ["base-1", "base-2", "base-3"],
+  );
+});
+
+test("selection clears on track switch and prunes on active track reload", async () => {
+  const { result } = renderHook(() => useSubtitleContext(), { wrapper });
+
+  await act(async () => {
+    result.current.setInitialSubtitles([...threeSubtitles], "Track Alpha");
+  });
+
+  await waitFor(() => {
+    assert.ok(result.current.activeTrackId);
+  });
+  const trackA = result.current.activeTrackId!;
+
+  await act(async () => {
+    result.current.selectSubtitleWithModifiers("base-2");
+  });
+  assert.deepEqual(Array.from(result.current.selectedSubtitleUuids), [
+    "base-2",
+  ]);
+
+  await act(async () => {
+    result.current.addTrack("Track Beta", [
+      {
+        uuid: "beta-1",
+        id: 1,
+        startTime: "00:00:10,000",
+        endTime: "00:00:12,000",
+        text: "Beta cue",
+      },
+    ]);
+  });
+  const trackB = result.current.tracks.find((track) => track.id !== trackA)?.id;
+  assert.ok(trackB);
+
+  await act(async () => {
+    result.current.setActiveTrackId(trackB!);
+  });
+
+  await waitFor(() => {
+    assert.equal(result.current.activeTrackId, trackB);
+    assert.equal(result.current.selectedSubtitleUuids.size, 0);
+  });
+
+  await act(async () => {
+    result.current.setActiveTrackId(trackA);
+  });
+  await waitFor(() => {
+    assert.equal(result.current.activeTrackId, trackA);
+  });
+
+  await act(async () => {
+    result.current.selectSubtitleWithModifiers("base-1");
+    result.current.selectSubtitleWithModifiers("base-3", { ctrlKey: true });
+  });
+
+  await act(async () => {
+    result.current.loadSubtitlesIntoTrack(trackA, [threeSubtitles[1]]);
+  });
+
+  await waitFor(() => {
+    assert.equal(result.current.subtitles.length, 1);
+    assert.equal(result.current.selectedSubtitleUuids.size, 0);
+  });
 });
 
 test("splitSubtitleAction respects pending text before splitting", async () => {

--- a/tests/subtitle-selection.test.ts
+++ b/tests/subtitle-selection.test.ts
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  applySubtitleSelectionInteraction,
+  pruneSubtitleSelection,
+} from "../lib/subtitle-selection";
+
+const orderedUuids = ["s1", "s2", "s3", "s4"];
+
+test("plain click selects one subtitle and sets the anchor", () => {
+  const result = applySubtitleSelectionInteraction({
+    orderedUuids,
+    selectedUuids: new Set(["s1", "s2"]),
+    anchorUuid: "s1",
+    targetUuid: "s3",
+  });
+
+  assert.deepEqual(Array.from(result.selectedUuids), ["s3"]);
+  assert.equal(result.anchorUuid, "s3");
+});
+
+test("cmd or ctrl click toggles one subtitle and sets the anchor", () => {
+  const selected = applySubtitleSelectionInteraction({
+    orderedUuids,
+    selectedUuids: new Set(["s1"]),
+    anchorUuid: "s1",
+    targetUuid: "s3",
+    modifiers: { ctrlKey: true },
+  });
+
+  assert.deepEqual(Array.from(selected.selectedUuids), ["s1", "s3"]);
+  assert.equal(selected.anchorUuid, "s3");
+
+  const deselected = applySubtitleSelectionInteraction({
+    orderedUuids,
+    selectedUuids: selected.selectedUuids,
+    anchorUuid: selected.anchorUuid,
+    targetUuid: "s1",
+    modifiers: { metaKey: true },
+  });
+
+  assert.deepEqual(Array.from(deselected.selectedUuids), ["s3"]);
+  assert.equal(deselected.anchorUuid, "s1");
+});
+
+test("shift click replaces selection with an anchor range", () => {
+  const result = applySubtitleSelectionInteraction({
+    orderedUuids,
+    selectedUuids: new Set(["s4"]),
+    anchorUuid: "s2",
+    targetUuid: "s4",
+    modifiers: { shiftKey: true, ctrlKey: true },
+  });
+
+  assert.deepEqual(Array.from(result.selectedUuids), ["s2", "s3", "s4"]);
+  assert.equal(result.anchorUuid, "s2");
+});
+
+test("pruneSubtitleSelection removes unavailable selected and anchor UUIDs", () => {
+  const result = pruneSubtitleSelection(
+    new Set(["s1", "s3", "missing"]),
+    "missing",
+    ["s1", "s2", "s3"],
+  );
+
+  assert.deepEqual(Array.from(result.selectedUuids), ["s1", "s3"]);
+  assert.equal(result.anchorUuid, null);
+});


### PR DESCRIPTION
## Summary

Closes #39.

- Adds active-track multi-select state for the main subtitle list, keyed by subtitle UUID.
- Supports plain click, Cmd/Ctrl-click, Shift-click, Escape clear, and Delete selected cues.
- Adds undo-backed selected-cue deletion in one history step.
- Seeds Bulk Offset from the main-list selection when present, while keeping the drawer's own selection after it opens.

## Validation

- `npm run lint` ✅
- `npm test` ✅ (56 tests)
- `npm run build` ⚠️ blocked locally because this environment times out fetching `Geist` and `Geist Mono` from `https://fonts.googleapis.com`; `curl` to the same Google Fonts URL also timed out.
