### PR TITLE
[codex] Add local autosave session recovery

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -7,6 +7,7 @@ import type {
   BulkOffsetPreviewState,
 } from "@/components/bulk-offset/drawer";
 import CustomControls from "@/components/custom-controls";
+import LocalSessionRecovery from "@/components/local-session-recovery";
 import SkipLinks from "@/components/skip-links";
 import type { SubtitleListRef } from "@/components/subtitle/subtitle-list";
 import TrackTabs from "@/components/subtitle/track-tabs";
@@ -514,6 +515,7 @@ function MainContent() {
 export default function Home() {
   return (
     <SubtitleProvider>
+      <LocalSessionRecovery />
       <MainContent />
     </SubtitleProvider>
   );

--- a/components/app-header/settings-dialog.tsx
+++ b/components/app-header/settings-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -9,9 +10,13 @@ import {
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
-import { useSubtitleState } from "@/context/subtitle-context";
+import {
+  useLocalSession,
+  useSubtitleState,
+} from "@/context/subtitle-context";
+import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
-import { IconMoon, IconSun } from "@tabler/icons-react";
+import { IconMoon, IconSun, IconTrash } from "@tabler/icons-react";
 import { motion } from "motion/react";
 import { useTranslations } from "next-intl";
 import { useTheme } from "next-themes";
@@ -28,6 +33,8 @@ export default function SettingsDialog({
 }: SettingsDialogProps) {
   const t = useTranslations();
   const { resolvedTheme, setTheme } = useTheme();
+  const { toast } = useToast();
+  const { hasLocalSession, clearLocalSession } = useLocalSession();
   const [isThemeMounted, setIsThemeMounted] = useState(false);
   const {
     clampOverlaps,
@@ -43,6 +50,14 @@ export default function SettingsDialog({
   const subtitleDurationId = useId();
   const addSpaceOnMergeId = useId();
   const playInBackgroundId = useId();
+
+  const handleClearLocalSession = () => {
+    clearLocalSession();
+    toast({
+      title: t("localSession.clearedTitle"),
+      description: t("localSession.clearedDescription"),
+    });
+  };
 
   useEffect(() => {
     setIsThemeMounted(true);
@@ -180,6 +195,29 @@ export default function SettingsDialog({
               checked={playInBackground}
               onCheckedChange={(value) => setPlayInBackground(value)}
             />
+          </div>
+
+          <div className="flex items-center justify-between gap-4">
+            <div className="space-y-1">
+              <Label className="text-sm">
+                {t("localSession.settingsClearLabel")}
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                {t("localSession.settingsClearDescription")}
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={!hasLocalSession}
+              onClick={handleClearLocalSession}
+            >
+              <IconTrash size={16} />
+              {hasLocalSession
+                ? t("localSession.clear")
+                : t("localSession.noAutosave")}
+            </Button>
           </div>
         </div>
       </DialogContent>

--- a/components/local-session-recovery.tsx
+++ b/components/local-session-recovery.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useLocalSession } from "@/context/subtitle-context";
+import {
+  IconDownload,
+  IconRestore,
+  IconTrash,
+} from "@tabler/icons-react";
+import { useTranslations } from "next-intl";
+import { useEffect, useMemo, useState } from "react";
+
+export default function LocalSessionRecovery() {
+  const t = useTranslations();
+  const {
+    pendingLocalSession,
+    restoreLocalSession,
+    discardLocalSession,
+    downloadLocalSessionBackup,
+  } = useLocalSession();
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  const sessionSummary = useMemo(() => {
+    if (!pendingLocalSession) {
+      return null;
+    }
+    const trackCount = pendingLocalSession.tracks.length;
+    const subtitleCount = pendingLocalSession.tracks.reduce(
+      (total, track) => total + track.subtitles.length,
+      0,
+    );
+    const savedAt = new Intl.DateTimeFormat(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(new Date(pendingLocalSession.savedAt));
+
+    return { trackCount, subtitleCount, savedAt };
+  }, [pendingLocalSession]);
+
+  if (!isMounted || !pendingLocalSession || !sessionSummary) {
+    return null;
+  }
+
+  return (
+    <Dialog open>
+      <DialogContent className="sm:max-w-lg" hideClose>
+        <DialogHeader>
+          <DialogTitle>{t("localSession.title")}</DialogTitle>
+          <DialogDescription>
+            {t("localSession.description")}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 rounded-sm border border-black/10 bg-neutral-50 p-4 text-sm dark:border-white/10 dark:bg-neutral-900">
+          <p className="font-medium">
+            {t("localSession.summary", {
+              tracks: sessionSummary.trackCount,
+              subtitles: sessionSummary.subtitleCount,
+            })}
+          </p>
+          <p className="text-muted-foreground">
+            {t("localSession.savedAt", { time: sessionSummary.savedAt })}
+          </p>
+          <p className="text-muted-foreground">
+            {t("localSession.privacy")}
+          </p>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => downloadLocalSessionBackup(pendingLocalSession)}
+          >
+            <IconDownload />
+            {t("localSession.downloadBackup")}
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={discardLocalSession}
+          >
+            <IconTrash />
+            {t("localSession.discard")}
+          </Button>
+          <Button type="button" onClick={restoreLocalSession}>
+            <IconRestore />
+            {t("localSession.restore")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/context/subtitle-context.tsx
+++ b/context/subtitle-context.tsx
@@ -11,6 +11,17 @@ import {
   subtitlesAreEqual,
   EMPTY_HISTORY,
 } from "@/lib/subtitle-history";
+import {
+  buildLocalSessionBackup,
+  clearLocalSessionSnapshot,
+  createLocalSessionSnapshot,
+  getLocalSessionBackupFilename,
+  readLocalSessionSnapshot,
+  shouldAutosaveLocalSession,
+  writeLocalSessionSnapshot,
+  type LocalSessionPreferences,
+  type LocalSessionSnapshot,
+} from "@/lib/local-session";
 import { timeToSeconds } from "@/lib/utils";
 import type { Subtitle, SubtitleTrack } from "@/types/subtitle";
 import React, {
@@ -57,6 +68,17 @@ type SubtitleContextType = SubtitleStateValue &
     subtitles: Subtitle[];
   };
 
+interface LocalSessionValue {
+  pendingLocalSession: LocalSessionSnapshot | null;
+  hasLocalSession: boolean;
+  restoreLocalSession: () => void;
+  discardLocalSession: () => void;
+  clearLocalSession: () => void;
+  downloadLocalSessionBackup: (
+    snapshot?: LocalSessionSnapshot | null,
+  ) => void;
+}
+
 interface SubtitleTimingEntry {
   uuid: string;
   start: number;
@@ -81,10 +103,25 @@ const SubtitleDataContext = createContext<Subtitle[] | undefined>(undefined);
 const SubtitleTimingContext = createContext<SubtitleTimingState | undefined>(
   undefined,
 );
+const LocalSessionContext = createContext<LocalSessionValue | undefined>(
+  undefined,
+);
 
 interface SubtitleProviderProps {
   children: ReactNode;
 }
+
+const readRecoverableLocalSession = (): LocalSessionSnapshot | null => {
+  const snapshot = readLocalSessionSnapshot();
+  return snapshot && shouldAutosaveLocalSession(snapshot) ? snapshot : null;
+};
+
+const getLocalSessionFingerprint = (snapshot: LocalSessionSnapshot): string =>
+  JSON.stringify({
+    tracks: snapshot.tracks,
+    activeTrackId: snapshot.activeTrackId,
+    preferences: snapshot.preferences,
+  });
 
 export function SubtitleProvider({ children }: SubtitleProviderProps) {
   const [tracks, setTracks] = useState<SubtitleTrack[]>([]);
@@ -95,7 +132,13 @@ export function SubtitleProvider({ children }: SubtitleProviderProps) {
   const [addSpaceOnMerge, setAddSpaceOnMerge] = useState<boolean>(false);
   const [clampOverlaps, setClampOverlaps] = useState<boolean>(true);
   const [playInBackground, setPlayInBackground] = useState<boolean>(false);
+  const [pendingLocalSession, setPendingLocalSession] =
+    useState<LocalSessionSnapshot | null>(() => readRecoverableLocalSession());
+  const [hasLocalSession, setHasLocalSession] = useState(
+    () => readRecoverableLocalSession() !== null,
+  );
   const previousActiveTrackId = useRef<string | null>(null);
+  const suppressedAutosaveFingerprintRef = useRef<string | null>(null);
   const trackHistoriesRef = useRef<Map<string, UndoHistory<Subtitle[]>>>(
     new Map(),
   );
@@ -113,6 +156,144 @@ export function SubtitleProvider({ children }: SubtitleProviderProps) {
   ] = useUndoableState<Subtitle[]>([], {
     isEqual: subtitlesAreEqual,
   });
+
+  const localSessionPreferences = useMemo<LocalSessionPreferences>(
+    () => ({
+      showTrackLabels,
+      showSubtitleDuration,
+      addSpaceOnMerge,
+      clampOverlaps,
+      playInBackground,
+    }),
+    [
+      showTrackLabels,
+      showSubtitleDuration,
+      addSpaceOnMerge,
+      clampOverlaps,
+      playInBackground,
+    ],
+  );
+
+  const createCurrentLocalSession = useCallback(
+    () =>
+      createLocalSessionSnapshot({
+        tracks,
+        activeTrackId,
+        preferences: localSessionPreferences,
+      }),
+    [activeTrackId, localSessionPreferences, tracks],
+  );
+
+  useEffect(() => {
+    if (pendingLocalSession) {
+      return;
+    }
+
+    const snapshot = createCurrentLocalSession();
+    const snapshotFingerprint = getLocalSessionFingerprint(snapshot);
+    const timeoutId = window.setTimeout(() => {
+      if (suppressedAutosaveFingerprintRef.current === snapshotFingerprint) {
+        return;
+      }
+
+      if (shouldAutosaveLocalSession(snapshot)) {
+        const didWrite = writeLocalSessionSnapshot(snapshot);
+        if (didWrite) {
+          suppressedAutosaveFingerprintRef.current = null;
+          setHasLocalSession(true);
+        }
+        return;
+      }
+
+      const didClear = clearLocalSessionSnapshot();
+      if (didClear) {
+        setHasLocalSession(false);
+      }
+    }, 750);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [createCurrentLocalSession, pendingLocalSession]);
+
+  const restoreLocalSession = useCallback(() => {
+    if (!pendingLocalSession) {
+      return;
+    }
+
+    const nextHistories = new Map<string, UndoHistory<Subtitle[]>>();
+    const nextTracks = pendingLocalSession.tracks.map((track) => {
+      const history = createTrackHistory(track.id, track.subtitles);
+      nextHistories.set(track.id, history);
+      return {
+        ...track,
+        subtitles: history.present,
+        vttPrologue: track.vttPrologue ? [...track.vttPrologue] : undefined,
+      };
+    });
+    const nextActiveTrackId =
+      pendingLocalSession.activeTrackId &&
+      nextTracks.some((track) => track.id === pendingLocalSession.activeTrackId)
+        ? pendingLocalSession.activeTrackId
+        : (nextTracks[0]?.id ?? null);
+
+    trackHistoriesRef.current = nextHistories;
+    setTracks(nextTracks);
+    setActiveTrackId(nextActiveTrackId);
+    setShowTrackLabels(pendingLocalSession.preferences.showTrackLabels);
+    setShowSubtitleDuration(
+      pendingLocalSession.preferences.showSubtitleDuration,
+    );
+    setAddSpaceOnMerge(pendingLocalSession.preferences.addSpaceOnMerge);
+    setClampOverlaps(pendingLocalSession.preferences.clampOverlaps);
+    setPlayInBackground(pendingLocalSession.preferences.playInBackground);
+    setHistorySnapshot(
+      nextActiveTrackId
+        ? (nextHistories.get(nextActiveTrackId) ?? EMPTY_HISTORY)
+        : EMPTY_HISTORY,
+    );
+    suppressedAutosaveFingerprintRef.current = null;
+    setPendingLocalSession(null);
+    setHasLocalSession(true);
+  }, [pendingLocalSession, setHistorySnapshot]);
+
+  const discardLocalSession = useCallback(() => {
+    clearLocalSessionSnapshot();
+    suppressedAutosaveFingerprintRef.current = null;
+    setPendingLocalSession(null);
+    setHasLocalSession(false);
+  }, []);
+
+  const clearLocalSession = useCallback(() => {
+    suppressedAutosaveFingerprintRef.current = getLocalSessionFingerprint(
+      createCurrentLocalSession(),
+    );
+    clearLocalSessionSnapshot();
+    setPendingLocalSession(null);
+    setHasLocalSession(false);
+  }, [createCurrentLocalSession]);
+
+  const downloadLocalSessionBackup = useCallback(
+    (snapshot?: LocalSessionSnapshot | null) => {
+      const session = snapshot ?? pendingLocalSession ?? createCurrentLocalSession();
+      if (!session || !shouldAutosaveLocalSession(session)) {
+        return;
+      }
+
+      const blob = new Blob([buildLocalSessionBackup(session)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = getLocalSessionBackupFilename(session);
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    },
+    [createCurrentLocalSession, pendingLocalSession],
+  );
 
   useEffect(() => {
     const snapshot = getHistorySnapshot();
@@ -270,18 +451,39 @@ export function SubtitleProvider({ children }: SubtitleProviderProps) {
     return { list, byUuid };
   }, [activeSubtitles]);
 
+  const localSessionValue = useMemo<LocalSessionValue>(
+    () => ({
+      pendingLocalSession,
+      hasLocalSession,
+      restoreLocalSession,
+      discardLocalSession,
+      clearLocalSession,
+      downloadLocalSessionBackup,
+    }),
+    [
+      pendingLocalSession,
+      hasLocalSession,
+      restoreLocalSession,
+      discardLocalSession,
+      clearLocalSession,
+      downloadLocalSessionBackup,
+    ],
+  );
+
   return (
-    <SubtitleActionsContext.Provider value={subtitleActions}>
-      <SubtitleHistoryContext.Provider value={historyValue}>
-        <SubtitleStateContext.Provider value={stateValue}>
-          <SubtitleTimingContext.Provider value={timingState}>
-            <SubtitleDataContext.Provider value={activeSubtitles}>
-              {children}
-            </SubtitleDataContext.Provider>
-          </SubtitleTimingContext.Provider>
-        </SubtitleStateContext.Provider>
-      </SubtitleHistoryContext.Provider>
-    </SubtitleActionsContext.Provider>
+    <LocalSessionContext.Provider value={localSessionValue}>
+      <SubtitleActionsContext.Provider value={subtitleActions}>
+        <SubtitleHistoryContext.Provider value={historyValue}>
+          <SubtitleStateContext.Provider value={stateValue}>
+            <SubtitleTimingContext.Provider value={timingState}>
+              <SubtitleDataContext.Provider value={activeSubtitles}>
+                {children}
+              </SubtitleDataContext.Provider>
+            </SubtitleTimingContext.Provider>
+          </SubtitleStateContext.Provider>
+        </SubtitleHistoryContext.Provider>
+      </SubtitleActionsContext.Provider>
+    </LocalSessionContext.Provider>
   );
 }
 
@@ -305,6 +507,11 @@ export const useSubtitleActionsContext = (): SubtitleActions => {
 export const useSubtitleHistory = (): SubtitleHistoryValue => {
   const ctx = useContext(SubtitleHistoryContext);
   return ensureContext(ctx, "useSubtitleHistory");
+};
+
+export const useLocalSession = (): LocalSessionValue => {
+  const ctx = useContext(LocalSessionContext);
+  return ensureContext(ctx, "useLocalSession");
 };
 
 export const useSubtitles = (): Subtitle[] => {

--- a/docs/superpowers/plans/2026-05-24-local-autosave-session-recovery.md
+++ b/docs/superpowers/plans/2026-05-24-local-autosave-session-recovery.md
@@ -1,0 +1,185 @@
+# Local Autosave Session Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Add local autosave and recovery for browser-only subtitle editing sessions from GitHub issue #40.
+
+**Architecture:** Keep autosave serialization in a pure `lib/local-session.ts` module, wire debounced persistence and restore actions into `SubtitleProvider`, and render recovery/settings controls through small client components. The snapshot intentionally stores subtitle/project data and editor preferences only, never media file contents.
+
+**Tech Stack:** Next.js 16 App Router, React 19 client components, Node `node:test`, jsdom, localStorage.
+
+---
+
+## File Structure
+
+- Create: `lib/local-session.ts` for versioned snapshot types, parsing, serialization, storage wrappers, and backup file helpers.
+- Create: `tests/local-session.test.ts` for pure schema/storage coverage.
+- Modify: `context/subtitle-context.tsx` to read pending autosaves on mount, debounce writes, expose restore/discard/clear/download state, and rebuild per-track undo histories after restore.
+- Modify: `tests/subtitle-context.test.ts` for provider-level autosave write and recovery behavior.
+- Create: `components/local-session-recovery.tsx` for the restore/discard/download recovery dialog.
+- Modify: `components/app-header/settings-dialog.tsx` for a clear-autosave setting.
+- Modify: `app/[locale]/page.tsx` to mount the recovery dialog under `SubtitleProvider`.
+- Modify: `messages/en.json`, `messages/de.json`, and `messages/yue.json` for visible recovery/settings copy.
+
+### Task 1: Local Session Schema
+
+**Files:**
+- Create: `lib/local-session.ts`
+- Create: `tests/local-session.test.ts`
+
+- [x] **Step 1: Write failing schema/storage tests**
+
+```ts
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  LOCAL_SESSION_STORAGE_KEY,
+  createLocalSessionSnapshot,
+  parseLocalSessionSnapshot,
+  readLocalSessionSnapshot,
+  writeLocalSessionSnapshot,
+  clearLocalSessionSnapshot,
+} from "../lib/local-session";
+
+test("local session snapshots persist tracks and editor preferences", () => {
+  const snapshot = createLocalSessionSnapshot({
+    tracks: [{ id: "track-1", name: "English", subtitles: [{ uuid: "cue-1", id: 1, startTime: "00:00:00,000", endTime: "00:00:01,000", text: "Hello", trackId: "track-1" }] }],
+    activeTrackId: "track-1",
+    preferences: { showTrackLabels: true, showSubtitleDuration: true, addSpaceOnMerge: true, clampOverlaps: false, playInBackground: true },
+    now: () => 1234,
+    appVersion: "0.1.0",
+  });
+
+  assert.equal(snapshot.schemaVersion, 1);
+  assert.equal(snapshot.tracks[0].name, "English");
+  assert.equal(snapshot.preferences.showTrackLabels, true);
+});
+
+test("parseLocalSessionSnapshot rejects corrupt or unsupported payloads", () => {
+  assert.equal(parseLocalSessionSnapshot("{nope"), null);
+  assert.equal(parseLocalSessionSnapshot(JSON.stringify({ schemaVersion: 999 })), null);
+});
+
+test("storage helpers use the autosave namespace and tolerate clearing", () => {
+  const storage = new Map<string, string>();
+  const adapter = { getItem: (key: string) => storage.get(key) ?? null, setItem: (key: string, value: string) => storage.set(key, value), removeItem: (key: string) => storage.delete(key) };
+  const snapshot = createLocalSessionSnapshot({
+    tracks: [{ id: "track-1", name: "English", subtitles: [{ uuid: "cue-1", id: 1, startTime: "00:00:00,000", endTime: "00:00:01,000", text: "Hello" }] }],
+    activeTrackId: "track-1",
+    preferences: { showTrackLabels: false, showSubtitleDuration: false, addSpaceOnMerge: false, clampOverlaps: true, playInBackground: false },
+    now: () => 1234,
+  });
+
+  writeLocalSessionSnapshot(snapshot, adapter);
+  assert.ok(storage.has(LOCAL_SESSION_STORAGE_KEY));
+  assert.equal(readLocalSessionSnapshot(adapter)?.tracks[0].id, "track-1");
+  clearLocalSessionSnapshot(adapter);
+  assert.equal(readLocalSessionSnapshot(adapter), null);
+});
+```
+
+- [x] **Step 2: Verify the tests fail**
+
+Run: `npm test -- tests/local-session.test.ts`
+
+Expected: FAIL because `lib/local-session.ts` does not exist.
+
+- [x] **Step 3: Implement the pure schema module**
+
+Add `LOCAL_SESSION_STORAGE_KEY = "subtitle-editor:autosave:v1"`, `LocalSessionSnapshot`, `LocalSessionPreferences`, `createLocalSessionSnapshot`, `parseLocalSessionSnapshot`, `readLocalSessionSnapshot`, `writeLocalSessionSnapshot`, and `clearLocalSessionSnapshot`. Validate schema version 1, timestamps, tracks, subtitles, and preference booleans. Reject unsupported/corrupt snapshots by returning `null`.
+
+- [x] **Step 4: Verify schema/storage tests pass**
+
+Run: `npm test -- tests/local-session.test.ts`
+
+Expected: PASS.
+
+### Task 2: Provider Autosave and Recovery Actions
+
+**Files:**
+- Modify: `context/subtitle-context.tsx`
+- Modify: `tests/subtitle-context.test.ts`
+
+- [x] **Step 1: Write failing provider tests**
+
+Add tests that render `SubtitleProvider`, load subtitles, wait for a debounced autosave write into jsdom `localStorage`, remount with that saved payload, verify a pending recovery is exposed before restore, call restore, and assert tracks/preferences/active subtitles are restored. Add discard/clear assertions that remove `subtitle-editor:autosave:v1`.
+
+- [x] **Step 2: Verify provider tests fail**
+
+Run: `npm test -- tests/subtitle-context.test.ts`
+
+Expected: FAIL because local session state/actions do not exist yet.
+
+- [x] **Step 3: Implement provider wiring**
+
+Extend the context with a local-session value containing `pendingLocalSession`, `hasLocalSession`, `restoreLocalSession`, `discardLocalSession`, `clearLocalSession`, and `downloadLocalSessionBackup`. On mount, read localStorage once and hold a recoverable pending snapshot. Debounce writes by 750 ms when tracks/preferences change, skip playback state, skip empty projects, and avoid overwriting while a pending snapshot awaits user choice. Restore should rebuild track histories with `createTrackHistory` and set the active track history.
+
+- [x] **Step 4: Verify provider tests pass**
+
+Run: `npm test -- tests/subtitle-context.test.ts`
+
+Expected: PASS.
+
+### Task 3: Recovery and Settings UI
+
+**Files:**
+- Create: `components/local-session-recovery.tsx`
+- Modify: `components/app-header/settings-dialog.tsx`
+- Modify: `app/[locale]/page.tsx`
+- Modify: `messages/en.json`
+- Modify: `messages/de.json`
+- Modify: `messages/yue.json`
+
+- [x] **Step 1: Add recovery dialog and settings control**
+
+Create a small recovery dialog that appears when `pendingLocalSession` exists. It shows the saved time, track count, subtitle count, local-only privacy copy, and three actions: restore, download backup, discard. Add a settings row with a clear-autosave button.
+
+- [x] **Step 2: Wire translations**
+
+Add `localSession` keys to all locale files for the recovery title, description, restore, discard, download backup, clear autosave, no autosave, and cleared copy.
+
+- [x] **Step 3: Mount the dialog**
+
+Render `<LocalSessionRecovery />` inside the `SubtitleProvider` in `app/[locale]/page.tsx` so it can read the subtitle context.
+
+- [x] **Step 4: Run static checks**
+
+Run: `npm run lint`
+
+Expected: PASS.
+
+### Task 4: Final Verification and PR
+
+**Files:**
+- All touched files
+
+- [x] **Step 1: Run full automated checks**
+
+Run:
+
+```bash
+npm test
+npm run lint
+npm run build
+```
+
+Expected: PASS. If `next/font` or external network causes build failure, capture the exact failure and rerun the non-network checks.
+
+- [x] **Step 2: Validate the rendered flow**
+
+Start the dev server, open the app, create/edit subtitles, reload, restore the autosaved session, discard another autosave, and clear autosave from settings. Check console health and one screenshot of the recovery dialog.
+
+- [x] **Step 3: Commit and publish**
+
+Run:
+
+```bash
+git status -sb
+git add docs/superpowers/plans/2026-05-24-local-autosave-session-recovery.md lib/local-session.ts tests/local-session.test.ts context/subtitle-context.tsx tests/subtitle-context.test.ts components/local-session-recovery.tsx components/app-header/settings-dialog.tsx app/[locale]/page.tsx messages/en.json messages/de.json messages/yue.json
+git commit -m "Add local autosave session recovery"
+git push -u origin codex/issue-40-local-autosave
+```
+
+- [x] **Step 4: Open draft PR**
+
+Open a draft PR against `main` with title `[codex] Add local autosave session recovery`. Include issue #40, summary, validation commands, and any known limitations.

--- a/lib/local-session.ts
+++ b/lib/local-session.ts
@@ -1,0 +1,277 @@
+import type { Subtitle, SubtitleTrack } from "@/types/subtitle";
+
+export const LOCAL_SESSION_STORAGE_KEY = "subtitle-editor:autosave:v1";
+export const LOCAL_SESSION_SCHEMA_VERSION = 1;
+
+export interface LocalSessionPreferences {
+  showTrackLabels: boolean;
+  showSubtitleDuration: boolean;
+  addSpaceOnMerge: boolean;
+  clampOverlaps: boolean;
+  playInBackground: boolean;
+}
+
+export interface LocalSessionSnapshot {
+  schemaVersion: typeof LOCAL_SESSION_SCHEMA_VERSION;
+  savedAt: number;
+  appVersion?: string;
+  tracks: SubtitleTrack[];
+  activeTrackId: string | null;
+  preferences: LocalSessionPreferences;
+}
+
+export interface CreateLocalSessionSnapshotInput {
+  tracks: SubtitleTrack[];
+  activeTrackId: string | null;
+  preferences: LocalSessionPreferences;
+  now?: () => number;
+  appVersion?: string;
+}
+
+export interface LocalSessionStorage {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+}
+
+const cloneSubtitle = (subtitle: Subtitle): Subtitle => ({
+  uuid: subtitle.uuid,
+  id: subtitle.id,
+  startTime: subtitle.startTime,
+  endTime: subtitle.endTime,
+  text: subtitle.text,
+  trackId: subtitle.trackId,
+});
+
+const cloneTrack = (track: SubtitleTrack): SubtitleTrack => ({
+  id: track.id,
+  name: track.name,
+  subtitles: track.subtitles.map(cloneSubtitle),
+  vttHeader: track.vttHeader,
+  vttPrologue: track.vttPrologue ? [...track.vttPrologue] : undefined,
+});
+
+const normalizeActiveTrackId = (
+  tracks: SubtitleTrack[],
+  activeTrackId: string | null,
+): string | null => {
+  if (activeTrackId && tracks.some((track) => track.id === activeTrackId)) {
+    return activeTrackId;
+  }
+  return tracks[0]?.id ?? null;
+};
+
+export function createLocalSessionSnapshot({
+  tracks,
+  activeTrackId,
+  preferences,
+  now = Date.now,
+  appVersion,
+}: CreateLocalSessionSnapshotInput): LocalSessionSnapshot {
+  const clonedTracks = tracks.map(cloneTrack);
+  return {
+    schemaVersion: LOCAL_SESSION_SCHEMA_VERSION,
+    savedAt: now(),
+    appVersion,
+    tracks: clonedTracks,
+    activeTrackId: normalizeActiveTrackId(clonedTracks, activeTrackId),
+    preferences: { ...preferences },
+  };
+}
+
+export function shouldAutosaveLocalSession(
+  snapshot: LocalSessionSnapshot,
+): boolean {
+  return snapshot.tracks.some((track) => track.subtitles.length > 0);
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === "string");
+
+const parseSubtitle = (value: unknown): Subtitle | null => {
+  if (!isRecord(value)) return null;
+  if (
+    typeof value.uuid !== "string" ||
+    typeof value.id !== "number" ||
+    !Number.isFinite(value.id) ||
+    typeof value.startTime !== "string" ||
+    typeof value.endTime !== "string" ||
+    typeof value.text !== "string"
+  ) {
+    return null;
+  }
+  if (value.trackId !== undefined && typeof value.trackId !== "string") {
+    return null;
+  }
+  return {
+    uuid: value.uuid,
+    id: value.id,
+    startTime: value.startTime,
+    endTime: value.endTime,
+    text: value.text,
+    trackId: value.trackId,
+  };
+};
+
+const parseTrack = (value: unknown): SubtitleTrack | null => {
+  if (!isRecord(value)) return null;
+  if (
+    typeof value.id !== "string" ||
+    typeof value.name !== "string" ||
+    !Array.isArray(value.subtitles)
+  ) {
+    return null;
+  }
+  if (value.vttHeader !== undefined && typeof value.vttHeader !== "string") {
+    return null;
+  }
+  if (value.vttPrologue !== undefined && !isStringArray(value.vttPrologue)) {
+    return null;
+  }
+
+  const subtitles = value.subtitles.map(parseSubtitle);
+  if (subtitles.some((subtitle) => subtitle === null)) {
+    return null;
+  }
+
+  return {
+    id: value.id,
+    name: value.name,
+    subtitles: subtitles as Subtitle[],
+    vttHeader: value.vttHeader,
+    vttPrologue: value.vttPrologue,
+  };
+};
+
+const parsePreferences = (value: unknown): LocalSessionPreferences | null => {
+  if (!isRecord(value)) return null;
+  if (
+    typeof value.showTrackLabels !== "boolean" ||
+    typeof value.showSubtitleDuration !== "boolean" ||
+    typeof value.addSpaceOnMerge !== "boolean" ||
+    typeof value.clampOverlaps !== "boolean" ||
+    typeof value.playInBackground !== "boolean"
+  ) {
+    return null;
+  }
+  return {
+    showTrackLabels: value.showTrackLabels,
+    showSubtitleDuration: value.showSubtitleDuration,
+    addSpaceOnMerge: value.addSpaceOnMerge,
+    clampOverlaps: value.clampOverlaps,
+    playInBackground: value.playInBackground,
+  };
+};
+
+export function parseLocalSessionSnapshot(
+  raw: string,
+): LocalSessionSnapshot | null {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) return null;
+    if (parsed.schemaVersion !== LOCAL_SESSION_SCHEMA_VERSION) return null;
+    if (
+      typeof parsed.savedAt !== "number" ||
+      !Number.isFinite(parsed.savedAt) ||
+      !Array.isArray(parsed.tracks)
+    ) {
+      return null;
+    }
+    if (
+      parsed.appVersion !== undefined &&
+      typeof parsed.appVersion !== "string"
+    ) {
+      return null;
+    }
+    if (
+      parsed.activeTrackId !== null &&
+      typeof parsed.activeTrackId !== "string"
+    ) {
+      return null;
+    }
+
+    const tracks = parsed.tracks.map(parseTrack);
+    if (tracks.length === 0 || tracks.some((track) => track === null)) {
+      return null;
+    }
+
+    const preferences = parsePreferences(parsed.preferences);
+    if (!preferences) return null;
+
+    const sanitizedTracks = tracks as SubtitleTrack[];
+    return {
+      schemaVersion: LOCAL_SESSION_SCHEMA_VERSION,
+      savedAt: parsed.savedAt,
+      appVersion: parsed.appVersion,
+      tracks: sanitizedTracks,
+      activeTrackId: normalizeActiveTrackId(
+        sanitizedTracks,
+        parsed.activeTrackId,
+      ),
+      preferences,
+    };
+  } catch {
+    return null;
+  }
+}
+
+const getDefaultStorage = (): LocalSessionStorage | null => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return window.localStorage ?? null;
+};
+
+export function readLocalSessionSnapshot(
+  storage: LocalSessionStorage | null = getDefaultStorage(),
+): LocalSessionSnapshot | null {
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem(LOCAL_SESSION_STORAGE_KEY);
+    return raw ? parseLocalSessionSnapshot(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeLocalSessionSnapshot(
+  snapshot: LocalSessionSnapshot,
+  storage: LocalSessionStorage | null = getDefaultStorage(),
+): boolean {
+  if (!storage) return false;
+  try {
+    storage.setItem(LOCAL_SESSION_STORAGE_KEY, JSON.stringify(snapshot));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function clearLocalSessionSnapshot(
+  storage: LocalSessionStorage | null = getDefaultStorage(),
+): boolean {
+  if (!storage) return false;
+  try {
+    storage.removeItem(LOCAL_SESSION_STORAGE_KEY);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function buildLocalSessionBackup(snapshot: LocalSessionSnapshot): string {
+  return `${JSON.stringify(snapshot, null, 2)}\n`;
+}
+
+export function getLocalSessionBackupFilename(
+  snapshot: LocalSessionSnapshot,
+): string {
+  const date = new Date(snapshot.savedAt);
+  const safeDate = Number.isNaN(date.getTime())
+    ? "session"
+    : date.toISOString().replace(/[:.]/g, "-");
+  return `subtitle-editor-autosave-${safeDate}.json`;
+}

--- a/messages/de.json
+++ b/messages/de.json
@@ -150,6 +150,22 @@
     "playInBackgroundLabel": "Im Hintergrund abspielen",
     "playInBackgroundDescription": "Lässt die Wiedergabe weiterlaufen, wenn dieser Tab nicht aktiv ist."
   },
+  "localSession": {
+    "title": "Automatisch gespeicherte Sitzung wiederherstellen?",
+    "description": "Ein Untertitelprojekt wurde lokal in diesem Browser gespeichert.",
+    "summary": "{tracks, plural, =1 {# Spur} other {# Spuren}} · {subtitles, plural, =1 {# Untertitel} other {# Untertitel}}",
+    "savedAt": "Gespeichert {time}",
+    "privacy": "Autosave speichert nur Untertitel und Editor-Einstellungen. Mediendateien werden nicht gespeichert oder hochgeladen.",
+    "restore": "Wiederherstellen",
+    "downloadBackup": "Backup herunterladen",
+    "discard": "Verwerfen",
+    "settingsClearLabel": "Lokaler Autosave",
+    "settingsClearDescription": "Löscht die in diesem Browser gespeicherte Untertitelsitzung.",
+    "clear": "Autosave löschen",
+    "noAutosave": "Kein Autosave",
+    "clearedTitle": "Autosave gelöscht",
+    "clearedDescription": "Der lokale Autosave-Snapshot wurde aus diesem Browser entfernt."
+  },
   "subtitle": {
     "newSubtitle": "Neuer Untertitel",
     "subtitleCount": "{count, plural, =1 {# Untertitel} other {# Untertitel}}",

--- a/messages/en.json
+++ b/messages/en.json
@@ -150,6 +150,22 @@
     "playInBackgroundLabel": "Play in background",
     "playInBackgroundDescription": "Keep playback running when this tab is not active."
   },
+  "localSession": {
+    "title": "Restore autosaved session?",
+    "description": "A subtitle project was saved locally in this browser.",
+    "summary": "{tracks, plural, =1 {# track} other {# tracks}} · {subtitles, plural, =1 {# subtitle} other {# subtitles}}",
+    "savedAt": "Saved {time}",
+    "privacy": "Autosave stores subtitles and editor preferences only. Media files are not stored or uploaded.",
+    "restore": "Restore",
+    "downloadBackup": "Download backup",
+    "discard": "Discard",
+    "settingsClearLabel": "Local autosave",
+    "settingsClearDescription": "Clear the autosaved subtitle session stored in this browser.",
+    "clear": "Clear autosave",
+    "noAutosave": "No autosave",
+    "clearedTitle": "Autosave cleared",
+    "clearedDescription": "The local autosave snapshot was removed from this browser."
+  },
   "subtitle": {
     "newSubtitle": "New subtitle",
     "subtitleCount": "{count, plural, =1 {# subtitle} other {# subtitles}}",

--- a/messages/yue.json
+++ b/messages/yue.json
@@ -150,6 +150,22 @@
     "playInBackgroundLabel": "背景播放",
     "playInBackgroundDescription": "就算個分頁唔喺前景都繼續播放。"
   },
+  "localSession": {
+    "title": "還原自動儲存嘅工作？",
+    "description": "呢個瀏覽器入面有一份本機儲存嘅字幕工作。",
+    "summary": "{tracks} 條字幕軌 · {subtitles} 條字幕",
+    "savedAt": "{time} 儲存",
+    "privacy": "自動儲存只會保留字幕同編輯設定，唔會儲存或上載媒體檔案。",
+    "restore": "還原",
+    "downloadBackup": "下載備份",
+    "discard": "放棄",
+    "settingsClearLabel": "本機自動儲存",
+    "settingsClearDescription": "清除呢個瀏覽器入面嘅自動儲存字幕工作。",
+    "clear": "清除自動儲存",
+    "noAutosave": "冇自動儲存",
+    "clearedTitle": "已清除自動儲存",
+    "clearedDescription": "已經由呢個瀏覽器移除本機自動儲存快照。"
+  },
   "subtitle": {
     "newSubtitle": "新字幕",
     "subtitleCount": "{count} 條字幕",

--- a/tests/bulk-offset.test.ts
+++ b/tests/bulk-offset.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
-import { renderHook, act, waitFor } from "@testing-library/react";
+import { renderHook, act, waitFor, cleanup } from "@testing-library/react";
 import { createElement } from "react";
 import type { ReactNode } from "react";
 
@@ -64,6 +64,11 @@ const baseSubtitles = [
     text: "Third",
   },
 ];
+
+test.afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+});
 
 test("bulkShiftSubtitlesAction adjusts start times without crossing neighbours", async () => {
   const { result } = renderHook(() => useSubtitleContext(), { wrapper });

--- a/tests/local-session.test.ts
+++ b/tests/local-session.test.ts
@@ -1,0 +1,142 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { SubtitleTrack } from "../types/subtitle";
+import {
+  LOCAL_SESSION_STORAGE_KEY,
+  clearLocalSessionSnapshot,
+  createLocalSessionSnapshot,
+  parseLocalSessionSnapshot,
+  readLocalSessionSnapshot,
+  shouldAutosaveLocalSession,
+  writeLocalSessionSnapshot,
+} from "../lib/local-session";
+
+const preferences = {
+  showTrackLabels: true,
+  showSubtitleDuration: true,
+  addSpaceOnMerge: true,
+  clampOverlaps: false,
+  playInBackground: true,
+};
+
+const tracks: SubtitleTrack[] = [
+  {
+    id: "track-1",
+    name: "English",
+    vttHeader: "WEBVTT",
+    vttPrologue: ["NOTE kept"],
+    subtitles: [
+      {
+        uuid: "cue-1",
+        id: 1,
+        startTime: "00:00:00,000",
+        endTime: "00:00:01,000",
+        text: "Hello",
+        trackId: "track-1",
+      },
+    ],
+  },
+];
+
+test("local session snapshots persist tracks and editor preferences", () => {
+  const snapshot = createLocalSessionSnapshot({
+    tracks,
+    activeTrackId: "track-1",
+    preferences,
+    now: () => 1234,
+    appVersion: "0.1.0",
+  });
+
+  assert.equal(snapshot.schemaVersion, 1);
+  assert.equal(snapshot.savedAt, 1234);
+  assert.equal(snapshot.appVersion, "0.1.0");
+  assert.equal(snapshot.tracks[0].name, "English");
+  assert.equal(snapshot.tracks[0].vttPrologue?.[0], "NOTE kept");
+  assert.equal(snapshot.tracks[0].subtitles[0].text, "Hello");
+  assert.equal(snapshot.preferences.showTrackLabels, true);
+  assert.equal(snapshot.preferences.clampOverlaps, false);
+});
+
+test("parseLocalSessionSnapshot rejects corrupt or unsupported payloads", () => {
+  assert.equal(parseLocalSessionSnapshot("{nope"), null);
+  assert.equal(
+    parseLocalSessionSnapshot(JSON.stringify({ schemaVersion: 999 })),
+    null,
+  );
+  assert.equal(
+    parseLocalSessionSnapshot(
+      JSON.stringify({
+        schemaVersion: 1,
+        savedAt: 1234,
+        tracks: [],
+        preferences,
+      }),
+    ),
+    null,
+  );
+});
+
+test("parseLocalSessionSnapshot normalizes invalid active track IDs", () => {
+  const parsed = parseLocalSessionSnapshot(
+    JSON.stringify(
+      createLocalSessionSnapshot({
+        tracks,
+        activeTrackId: "missing",
+        preferences,
+        now: () => 1234,
+      }),
+    ),
+  );
+
+  assert.equal(parsed?.activeTrackId, "track-1");
+});
+
+test("shouldAutosaveLocalSession skips empty projects", () => {
+  const emptySnapshot = createLocalSessionSnapshot({
+    tracks: [{ id: "track-1", name: "Untitled", subtitles: [] }],
+    activeTrackId: "track-1",
+    preferences,
+    now: () => 1234,
+  });
+
+  assert.equal(shouldAutosaveLocalSession(emptySnapshot), false);
+  assert.equal(
+    shouldAutosaveLocalSession(
+      createLocalSessionSnapshot({
+        tracks,
+        activeTrackId: "track-1",
+        preferences,
+        now: () => 1234,
+      }),
+    ),
+    true,
+  );
+});
+
+test("storage helpers use the autosave namespace and tolerate clearing", () => {
+  const storage = new Map<string, string>();
+  const adapter = {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      storage.set(key, value);
+    },
+    removeItem: (key: string) => {
+      storage.delete(key);
+    },
+  };
+  const snapshot = createLocalSessionSnapshot({
+    tracks,
+    activeTrackId: "track-1",
+    preferences,
+    now: () => 1234,
+  });
+
+  writeLocalSessionSnapshot(snapshot, adapter);
+
+  assert.ok(storage.has(LOCAL_SESSION_STORAGE_KEY));
+  assert.equal(readLocalSessionSnapshot(adapter)?.tracks[0].id, "track-1");
+
+  clearLocalSessionSnapshot(adapter);
+
+  assert.equal(readLocalSessionSnapshot(adapter), null);
+});

--- a/tests/subtitle-context.test.ts
+++ b/tests/subtitle-context.test.ts
@@ -1,13 +1,18 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
-import { renderHook, act, waitFor } from "@testing-library/react";
+import { renderHook, act, waitFor, cleanup } from "@testing-library/react";
 import { createElement } from "react";
 import type { ReactNode } from "react";
 import {
   SubtitleProvider,
+  useLocalSession,
   useSubtitleContext,
 } from "../context/subtitle-context";
+import {
+  LOCAL_SESSION_STORAGE_KEY,
+  createLocalSessionSnapshot,
+} from "../lib/local-session";
 
 // Minimal DOM environment for React Testing Library
 const dom = new JSDOM("<!doctype html><html><body></body></html>", {
@@ -42,6 +47,21 @@ globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 const wrapper = ({ children }: { children: ReactNode }) =>
   createElement(SubtitleProvider, null, children);
 
+const renderSubtitleSession = () =>
+  renderHook(
+    () => ({
+      subtitles: useSubtitleContext(),
+      localSession: useLocalSession(),
+    }),
+    { wrapper },
+  );
+
+const waitForAutosave = async () => {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 800));
+  });
+};
+
 const baseSubtitles = [
   {
     uuid: "base-1",
@@ -58,6 +78,25 @@ const baseSubtitles = [
     text: "General Kenobi",
   },
 ];
+
+const savedTracks = [
+  {
+    id: "track-1",
+    name: "Saved Track",
+    subtitles: baseSubtitles.map((subtitle) => ({
+      ...subtitle,
+      trackId: "track-1",
+    })),
+  },
+];
+
+test.beforeEach(() => {
+  window.localStorage.clear();
+});
+
+test.afterEach(() => {
+  cleanup();
+});
 
 test("subtitle actions push history and support undo/redo cycles", async () => {
   const { result } = renderHook(() => useSubtitleContext(), { wrapper });
@@ -251,6 +290,172 @@ test("addSpaceOnMerge defaults to off and can be toggled", async () => {
   });
 
   assert.equal(result.current.addSpaceOnMerge, true);
+});
+
+test("provider debounces recoverable subtitle projects into localStorage", async () => {
+  const { result } = renderSubtitleSession();
+
+  await act(async () => {
+    result.current.subtitles.setInitialSubtitles(
+      [...baseSubtitles],
+      "Autosaved Track",
+      {
+        vttHeader: "WEBVTT",
+        vttPrologue: ["NOTE recovered"],
+      },
+    );
+    result.current.subtitles.setShowTrackLabels(true);
+    result.current.subtitles.setShowSubtitleDuration(true);
+    result.current.subtitles.setAddSpaceOnMerge(true);
+    result.current.subtitles.setClampOverlaps(false);
+    result.current.subtitles.setPlayInBackground(true);
+  });
+
+  await waitForAutosave();
+
+  const raw = window.localStorage.getItem(LOCAL_SESSION_STORAGE_KEY);
+  assert.ok(raw);
+  const parsed = JSON.parse(raw);
+  assert.equal(parsed.tracks[0].name, "Autosaved Track");
+  assert.equal(parsed.tracks[0].vttHeader, "WEBVTT");
+  assert.equal(parsed.tracks[0].vttPrologue[0], "NOTE recovered");
+  assert.equal(parsed.preferences.showTrackLabels, true);
+  assert.equal(parsed.preferences.showSubtitleDuration, true);
+  assert.equal(parsed.preferences.addSpaceOnMerge, true);
+  assert.equal(parsed.preferences.clampOverlaps, false);
+  assert.equal(parsed.preferences.playInBackground, true);
+});
+
+test("provider exposes pending local session and restores it on request", async () => {
+  const snapshot = createLocalSessionSnapshot({
+    tracks: [
+      {
+        id: "restored-track",
+        name: "Recovered Track",
+        subtitles: [
+          {
+            uuid: "restored-cue",
+            id: 1,
+            startTime: "00:00:02,000",
+            endTime: "00:00:05,000",
+            text: "Recovered line",
+            trackId: "restored-track",
+          },
+        ],
+      },
+    ],
+    activeTrackId: "restored-track",
+    preferences: {
+      showTrackLabels: true,
+      showSubtitleDuration: true,
+      addSpaceOnMerge: true,
+      clampOverlaps: false,
+      playInBackground: true,
+    },
+    now: () => 1234,
+  });
+  window.localStorage.setItem(
+    LOCAL_SESSION_STORAGE_KEY,
+    JSON.stringify(snapshot),
+  );
+
+  const { result } = renderSubtitleSession();
+
+  await waitFor(() => {
+    assert.equal(
+      result.current.localSession.pendingLocalSession?.tracks[0].name,
+      "Recovered Track",
+    );
+  });
+  assert.equal(result.current.subtitles.tracks.length, 0);
+
+  await act(async () => {
+    result.current.localSession.restoreLocalSession();
+  });
+
+  await waitFor(() => {
+    assert.equal(result.current.subtitles.tracks.length, 1);
+    assert.equal(result.current.subtitles.subtitles[0].text, "Recovered line");
+  });
+  assert.equal(result.current.localSession.pendingLocalSession, null);
+  assert.equal(result.current.subtitles.activeTrackId, "restored-track");
+  assert.equal(result.current.subtitles.showTrackLabels, true);
+  assert.equal(result.current.subtitles.showSubtitleDuration, true);
+  assert.equal(result.current.subtitles.addSpaceOnMerge, true);
+  assert.equal(result.current.subtitles.clampOverlaps, false);
+  assert.equal(result.current.subtitles.playInBackground, true);
+});
+
+test("provider discards and clears local autosave snapshots", async () => {
+  const snapshot = createLocalSessionSnapshot({
+    tracks: savedTracks,
+    activeTrackId: "track-1",
+    preferences: {
+      showTrackLabels: false,
+      showSubtitleDuration: false,
+      addSpaceOnMerge: false,
+      clampOverlaps: true,
+      playInBackground: false,
+    },
+    now: () => 1234,
+  });
+  window.localStorage.setItem(
+    LOCAL_SESSION_STORAGE_KEY,
+    JSON.stringify(snapshot),
+  );
+
+  const { result, unmount } = renderSubtitleSession();
+
+  await waitFor(() => {
+    assert.ok(result.current.localSession.pendingLocalSession);
+  });
+
+  await act(async () => {
+    result.current.localSession.discardLocalSession();
+  });
+
+  assert.equal(result.current.localSession.pendingLocalSession, null);
+  assert.equal(window.localStorage.getItem(LOCAL_SESSION_STORAGE_KEY), null);
+  unmount();
+
+  const second = renderSubtitleSession();
+
+  await act(async () => {
+    second.result.current.subtitles.setInitialSubtitles(
+      [...baseSubtitles],
+      "Clearable Track",
+    );
+  });
+
+  await waitForAutosave();
+  assert.ok(window.localStorage.getItem(LOCAL_SESSION_STORAGE_KEY));
+
+  await act(async () => {
+    second.result.current.localSession.clearLocalSession();
+  });
+
+  assert.equal(window.localStorage.getItem(LOCAL_SESSION_STORAGE_KEY), null);
+  assert.equal(second.result.current.localSession.hasLocalSession, false);
+});
+
+test("clearLocalSession cancels a pending autosave for the unchanged project", async () => {
+  const { result } = renderSubtitleSession();
+
+  await act(async () => {
+    result.current.subtitles.setInitialSubtitles(
+      [...baseSubtitles],
+      "Pending Clear Track",
+    );
+  });
+
+  await act(async () => {
+    result.current.localSession.clearLocalSession();
+  });
+
+  await waitForAutosave();
+
+  assert.equal(window.localStorage.getItem(LOCAL_SESSION_STORAGE_KEY), null);
+  assert.equal(result.current.localSession.hasLocalSession, false);
 });
 
 test("subtitles remain chronologically sorted after imports and edits", async () => {


### PR DESCRIPTION
## Summary

- Adds a versioned local autosave snapshot for subtitle projects under `subtitle-editor:autosave:v1`.
- Restores tracks, active track, VTT metadata, subtitles, and editor preferences without storing media files.
- Adds a recovery dialog with restore, discard, and JSON backup download actions, plus a settings control to clear local autosave.
- Adds regression coverage for corrupt snapshots, version handling, debounced provider writes, restore/discard/clear behavior, and the pending-write clear race.

Closes #40.

## Validation

- `npm test` (59 tests passing)
- `npm run lint`
- `npm run build`
- Browser QA at `http://localhost:3001/`: created a subtitle from scratch, waited for autosave, reloaded to verify the recovery dialog, restored the session, discarded a later autosave, cleared autosave from settings, reloaded to verify no recovery prompt, and checked console warnings/errors were empty.

## Notes

- Media file contents are intentionally not persisted. The snapshot contains subtitle tracks, VTT metadata, active track ID, and editor preferences only.
- `next build` still prints the existing Next.js middleware deprecation warning; build completes successfully.